### PR TITLE
fix: align all example and root pom versions to 0.10.0

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -10,7 +10,7 @@ on:
       asyncTestVersion:
         description: "Library version to test against (default: current build)"
         required: false
-        default: "0.9.0"
+        default: "0.10.0"
 
 permissions:
   contents: read
@@ -57,7 +57,7 @@ jobs:
       - name: Run load tests (fast subset — capped for CI)
         run: |
           ./gradlew -p load-tests test \
-            -PasyncTestVersion=${{ inputs.asyncTestVersion || '0.9.0' }} \
+            -PasyncTestVersion=${{ inputs.asyncTestVersion || '0.10.0' }} \
             -PloadTestFast=true
 
       - name: Upload throughput results

--- a/examples/01-completablefuture-exception-handling/build.gradle.kts
+++ b/examples/01-completablefuture-exception-handling/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
     mavenLocal()
 }
 
-val asyncTestVersion = "0.9.0"
+val asyncTestVersion = "0.10.0"
 val junitVersion = "5.10.2"
 // The library brings in junit-jupiter-engine:6.0.3 as an api dependency, which wins
 // over junitVersion above. Pin the launcher to match so Gradle's bundled 5.x launcher

--- a/examples/01-completablefuture-exception-handling/pom.xml
+++ b/examples/01-completablefuture-exception-handling/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
 
     <dependencies>

--- a/examples/02-visibility-volatile-flag/build.gradle.kts
+++ b/examples/02-visibility-volatile-flag/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
     mavenLocal()
 }
 
-val asyncTestVersion = "0.9.0"
+val asyncTestVersion = "0.10.0"
 val junitVersion = "5.10.2"
 // The library brings in junit-jupiter-engine:6.0.3 as an api dependency, which wins
 // over junitVersion above. Pin the launcher to match so Gradle's bundled 5.x launcher

--- a/examples/02-visibility-volatile-flag/pom.xml
+++ b/examples/02-visibility-volatile-flag/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
 
     <dependencies>

--- a/examples/03-shared-collection/pom.xml
+++ b/examples/03-shared-collection/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
 
     <dependencies>

--- a/examples/04-virtual-thread-context-leak/build.gradle.kts
+++ b/examples/04-virtual-thread-context-leak/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
     mavenLocal()
 }
 
-val asyncTestVersion = "0.9.0"
+val asyncTestVersion = "0.10.0"
 val junitVersion = "5.10.2"
 val junitPlatformVersion = "6.0.3"
 

--- a/examples/05-lock-contention/pom.xml
+++ b/examples/05-lock-contention/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
 
     <dependencies>

--- a/examples/09-uncommitted-changes-detection/build.gradle.kts
+++ b/examples/09-uncommitted-changes-detection/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
     mavenCentral()
 }
 
-val asyncTestVersion = "0.9.0"
+val asyncTestVersion = "0.10.0"
 val junitPlatformVersion = "6.0.3"
 
 dependencies {

--- a/examples/09-uncommitted-changes-detection/pom.xml
+++ b/examples/09-uncommitted-changes-detection/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
 
     <dependencies>

--- a/examples/10-shared-non-thread-safe-types/pom.xml
+++ b/examples/10-shared-non-thread-safe-types/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
 
     <dependencies>

--- a/examples/10-shared-non-thread-safe-types/src/test/java/se/deversity/asynctest/example/SharedNonThreadSafeTypesTest.java
+++ b/examples/10-shared-non-thread-safe-types/src/test/java/se/deversity/asynctest/example/SharedNonThreadSafeTypesTest.java
@@ -13,11 +13,11 @@ import static org.junit.jupiter.api.Assertions.*;
  * ========================================================================
  * NOTE: The Phase 11 detectors (detectSharedMatcher, detectSharedDecimalFormat,
  * detectSharedMessageDigest, detectWeakReferenceRace, detectStatefulLambda) ship
- * in async-test-lib 0.9.0. This example targets 0.8.0 so it runs from Maven
+ * in async-test-lib 0.10.0. This example targets 0.8.0 so it runs from Maven
  * Central without a local build.
  *
  * Upgrade steps (shown as comments throughout this file):
- *   1. Bump async-test-lib.version in pom.xml to 0.9.0
+ *   1. Bump async-test-lib.version in pom.xml to 0.10.0
  *   2. Change @Test to @AsyncTest on the three Part 2 methods
  *   3. Uncomment the AsyncTestContext detector calls inside each method
  * ========================================================================
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * thread touching the shared object at once, so no corruption occurs and all
  * assertions pass deterministically.
  *
- * WHY @AsyncTest DETECTS THE BUG (0.9.0):
+ * WHY @AsyncTest DETECTS THE BUG (0.10.0):
  * With multiple threads colliding on the same object simultaneously the detectors
  * report which threads accessed which instance — the access pattern alone is
  * sufficient to flag the risk, similar to a race detector:
@@ -90,17 +90,17 @@ class SharedNonThreadSafeTypesTest {
     //
     // Currently @Test so this compiles against 0.8.0.
     //
-    // To activate Phase 11 detection (requires 0.9.0):
-    //   1. Bump pom.xml: <async-test-lib.version>0.9.0</async-test-lib.version>
+    // To activate Phase 11 detection (requires 0.10.0):
+    //   1. Bump pom.xml: <async-test-lib.version>0.10.0</async-test-lib.version>
     //   2. Change @Test to @AsyncTest on each method below
     //   3. Uncomment the AsyncTestContext / import lines
     // =========================================================================
 
-    // import se.deversity.asynctest.AsyncTest;           // uncomment for 0.9.0
-    // import se.deversity.asynctest.AsyncTestContext;    // uncomment for 0.9.0
+    // import se.deversity.asynctest.AsyncTest;           // uncomment for 0.10.0
+    // import se.deversity.asynctest.AsyncTestContext;    // uncomment for 0.10.0
 
     /**
-     * Detector: SharedMatcherDetector (0.9.0)
+     * Detector: SharedMatcherDetector (0.10.0)
      *
      * Change to:
      *   @AsyncTest(threads = 8, invocations = 10, detectSharedMatcher = true)
@@ -112,7 +112,7 @@ class SharedNonThreadSafeTypesTest {
      */
     @Test
     void testSharedMatcher_concurrent() {
-        // With 0.9.0 — uncomment these lines and change to @AsyncTest above:
+        // With 0.10.0 — uncomment these lines and change to @AsyncTest above:
         // AsyncTestContext.sharedMatcherDetector()
         //     .recordAccess(service.getBuggyMatcher(), "txIdMatcher", Thread.currentThread());
 
@@ -121,7 +121,7 @@ class SharedNonThreadSafeTypesTest {
     }
 
     /**
-     * Detector: SharedDecimalFormatDetector (0.9.0)
+     * Detector: SharedDecimalFormatDetector (0.10.0)
      *
      * Change to:
      *   @AsyncTest(threads = 8, invocations = 10, detectSharedDecimalFormat = true)
@@ -132,7 +132,7 @@ class SharedNonThreadSafeTypesTest {
      */
     @Test
     void testSharedDecimalFormat_concurrent() {
-        // With 0.9.0 — uncomment these lines and change to @AsyncTest above:
+        // With 0.10.0 — uncomment these lines and change to @AsyncTest above:
         // AsyncTestContext.sharedDecimalFormatDetector()
         //     .recordAccess(service.getBuggyAmountFormat(), "amountFormat", Thread.currentThread());
 
@@ -141,7 +141,7 @@ class SharedNonThreadSafeTypesTest {
     }
 
     /**
-     * Detector: SharedMessageDigestDetector (0.9.0)
+     * Detector: SharedMessageDigestDetector (0.10.0)
      *
      * Change to:
      *   @AsyncTest(threads = 8, invocations = 10, detectSharedMessageDigest = true)
@@ -156,7 +156,7 @@ class SharedNonThreadSafeTypesTest {
      */
     @Test
     void testSharedMessageDigest_concurrent() {
-        // With 0.9.0 — uncomment these lines and change to @AsyncTest above:
+        // With 0.10.0 — uncomment these lines and change to @AsyncTest above:
         // AsyncTestContext.sharedMessageDigestDetector()
         //     .recordAccess(service.getBuggyMessageDigest(), "sha256", Thread.currentThread());
 
@@ -170,7 +170,7 @@ class SharedNonThreadSafeTypesTest {
 
     /**
      * The fixed versions use thread-local or per-call instances.
-     * Uncomment @AsyncTest (0.9.0) to verify the fixes hold under concurrent load.
+     * Uncomment @AsyncTest (0.10.0) to verify the fixes hold under concurrent load.
      */
     // @AsyncTest(threads = 8, invocations = 20,
     //         detectSharedMatcher = true, detectSharedDecimalFormat = true,

--- a/examples/11-interrupt-swallowing/pom.xml
+++ b/examples/11-interrupt-swallowing/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
 
     <dependencies>

--- a/examples/11-interrupt-swallowing/src/test/java/se/deversity/asynctest/example/InterruptSwallowingTest.java
+++ b/examples/11-interrupt-swallowing/src/test/java/se/deversity/asynctest/example/InterruptSwallowingTest.java
@@ -8,12 +8,11 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * ============================================================
  * NOTE: InterruptSwallowingDetector ships in async-test-lib 0.10.0.
- * This example targets 0.9.0 so it compiles from Maven Central.
+ * This example targets 0.10.0 so it compiles from Maven Central.
  *
  * Upgrade steps:
- *   1. Bump async-test-lib.version in pom.xml to 0.10.0
- *   2. Change the Part 2 @Test to @AsyncTest
- *   3. Uncomment the AsyncTestContext calls inside Part 2
+ *   1. Change the Part 2 @Test to @AsyncTest
+ *   2. Uncomment the AsyncTestContext calls inside Part 2
  * ============================================================
  *
  * THE BUG: A task runner catches InterruptedException but neither restores
@@ -70,7 +69,7 @@ class InterruptSwallowingTest {
 
     @Test
     void part2_detectInterruptSwallowing_placeholder() {
-        // Placeholder: run as plain @Test to compile against 0.9.0.
+        // Placeholder: run as plain @Test to compile against 0.10.0.
         // After upgrading to 0.10.0, replace with:
         //
         //   var d = AsyncTestContext.interruptSwallowingDetector();

--- a/examples/12-mdc-context-leak/pom.xml
+++ b/examples/12-mdc-context-leak/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency>

--- a/examples/12-mdc-context-leak/src/test/java/se/deversity/asynctest/example/MdcContextLeakTest.java
+++ b/examples/12-mdc-context-leak/src/test/java/se/deversity/asynctest/example/MdcContextLeakTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * ============================================================
  * NOTE: MdcContextLeakDetector ships in async-test-lib 0.10.0.
- * This example targets 0.9.0 so it compiles from Maven Central.
+ * This example targets 0.10.0 so it compiles from Maven Central.
  * ============================================================
  *
  * THE BUG: A request handler sets MDC keys (requestId, userId) for

--- a/examples/13-system-property-mutation/pom.xml
+++ b/examples/13-system-property-mutation/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency>

--- a/examples/13-system-property-mutation/src/test/java/se/deversity/asynctest/example/SystemPropertyMutationTest.java
+++ b/examples/13-system-property-mutation/src/test/java/se/deversity/asynctest/example/SystemPropertyMutationTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * ============================================================
  * NOTE: SystemPropertyMutationDetector ships in async-test-lib 0.10.0.
- * This example targets 0.9.0 so it compiles from Maven Central.
+ * This example targets 0.10.0 so it compiles from Maven Central.
  * ============================================================
  *
  * THE BUG: A configuration service reads and writes a system property

--- a/examples/14-future-ignored/pom.xml
+++ b/examples/14-future-ignored/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency>

--- a/examples/14-future-ignored/src/test/java/se/deversity/asynctest/example/FutureIgnoredTest.java
+++ b/examples/14-future-ignored/src/test/java/se/deversity/asynctest/example/FutureIgnoredTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * ============================================================
  * NOTE: FutureIgnoredDetector ships in async-test-lib 0.10.0.
- * This example targets 0.9.0 so it compiles from Maven Central.
+ * This example targets 0.10.0 so it compiles from Maven Central.
  * ============================================================
  *
  * THE BUG: An event bus submits background tasks but discards the

--- a/examples/15-explicit-gc/pom.xml
+++ b/examples/15-explicit-gc/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency><groupId>se.deversity.async-test-lib</groupId><artifactId>async-test-lib</artifactId><version>${async-test-lib.version}</version><scope>test</scope></dependency>

--- a/examples/15-explicit-gc/src/test/java/se/deversity/asynctest/example/ExplicitGcTest.java
+++ b/examples/15-explicit-gc/src/test/java/se/deversity/asynctest/example/ExplicitGcTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * ============================================================
  * NOTE: ExplicitGcDetector ships in async-test-lib 0.10.0.
- * This example targets 0.9.0 so it compiles from Maven Central.
+ * This example targets 0.10.0 so it compiles from Maven Central.
  * ============================================================
  *
  * THE BUG: A cache manager calls System.gc() to hint memory reclamation

--- a/examples/16-deprecated-thread-api/pom.xml
+++ b/examples/16-deprecated-thread-api/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency><groupId>se.deversity.async-test-lib</groupId><artifactId>async-test-lib</artifactId><version>${async-test-lib.version}</version><scope>test</scope></dependency>

--- a/examples/16-deprecated-thread-api/src/test/java/se/deversity/asynctest/example/DeprecatedThreadApiTest.java
+++ b/examples/16-deprecated-thread-api/src/test/java/se/deversity/asynctest/example/DeprecatedThreadApiTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * ============================================================
  * NOTE: DeprecatedThreadApiDetector ships in async-test-lib 0.10.0.
- * This example targets 0.9.0 so it compiles from Maven Central.
+ * This example targets 0.10.0 so it compiles from Maven Central.
  * ============================================================
  *
  * THE BUG: A thread manager uses Thread.stop() to forcibly terminate

--- a/examples/17-shared-xml-parser/pom.xml
+++ b/examples/17-shared-xml-parser/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency><groupId>se.deversity.async-test-lib</groupId><artifactId>async-test-lib</artifactId><version>${async-test-lib.version}</version><scope>test</scope></dependency>

--- a/examples/17-shared-xml-parser/src/test/java/se/deversity/asynctest/example/SharedXmlParserTest.java
+++ b/examples/17-shared-xml-parser/src/test/java/se/deversity/asynctest/example/SharedXmlParserTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * ============================================================
  * NOTE: SharedXmlParserDetector ships in async-test-lib 0.10.0.
- * This example targets 0.9.0 so it compiles from Maven Central.
+ * This example targets 0.10.0 so it compiles from Maven Central.
  * ============================================================
  *
  * THE BUG: An XML service holds a single shared DocumentBuilder.

--- a/examples/18-boxed-primitive-lock/pom.xml
+++ b/examples/18-boxed-primitive-lock/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency><groupId>se.deversity.async-test-lib</groupId><artifactId>async-test-lib</artifactId><version>${async-test-lib.version}</version><scope>test</scope></dependency>

--- a/examples/18-boxed-primitive-lock/src/test/java/se/deversity/asynctest/example/BoxedPrimitiveLockTest.java
+++ b/examples/18-boxed-primitive-lock/src/test/java/se/deversity/asynctest/example/BoxedPrimitiveLockTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * ============================================================
  * NOTE: BoxedPrimitiveLockDetector ships in async-test-lib 0.10.0.
- * This example targets 0.9.0 so it compiles from Maven Central.
+ * This example targets 0.10.0 so it compiles from Maven Central.
  * ============================================================
  *
  * THE BUG: A session registry uses a shared Integer (the session count,

--- a/examples/19-shared-timezone/pom.xml
+++ b/examples/19-shared-timezone/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency><groupId>se.deversity.async-test-lib</groupId><artifactId>async-test-lib</artifactId><version>${async-test-lib.version}</version><scope>test</scope></dependency>

--- a/examples/19-shared-timezone/src/test/java/se/deversity/asynctest/example/SharedTimeZoneTest.java
+++ b/examples/19-shared-timezone/src/test/java/se/deversity/asynctest/example/SharedTimeZoneTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * ============================================================
  * NOTE: SharedTimeZoneDetector ships in async-test-lib 0.10.0.
- * This example targets 0.9.0 so it compiles from Maven Central.
+ * This example targets 0.10.0 so it compiles from Maven Central.
  * ============================================================
  *
  * THE BUG: A scheduling service adjusts a shared TimeZone's raw offset

--- a/examples/20-uncaught-exception-handler/pom.xml
+++ b/examples/20-uncaught-exception-handler/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.9.0</async-test-lib.version>
+        <async-test-lib.version>0.10.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency><groupId>se.deversity.async-test-lib</groupId><artifactId>async-test-lib</artifactId><version>${async-test-lib.version}</version><scope>test</scope></dependency>

--- a/examples/20-uncaught-exception-handler/src/test/java/se/deversity/asynctest/example/UncaughtExceptionHandlerTest.java
+++ b/examples/20-uncaught-exception-handler/src/test/java/se/deversity/asynctest/example/UncaughtExceptionHandlerTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * ============================================================
  * NOTE: UncaughtExceptionHandlerDetector ships in async-test-lib 0.10.0.
- * This example targets 0.9.0 so it compiles from Maven Central.
+ * This example targets 0.10.0 so it compiles from Maven Central.
  * ============================================================
  *
  * THE BUG: A background worker thread throws an uncaught exception but

--- a/examples/README.md
+++ b/examples/README.md
@@ -220,7 +220,7 @@ examples/
 
 ---
 
-## Phase 11: Thread-Safety of Additional Types & Patterns (New in 0.9.0)
+## Phase 11: Thread-Safety of Additional Types & Patterns (New in 0.10.0)
 
 Five new detectors for JDK types that look thread-safe but silently corrupt state under
 concurrent use. All five follow the same manual-recording pattern — test code registers

--- a/load-tests/build.gradle.kts
+++ b/load-tests/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
     mavenCentral()
 }
 
-val asyncTestVersion: String = project.findProperty("asyncTestVersion") as String? ?: "0.9.0"
+val asyncTestVersion: String = project.findProperty("asyncTestVersion") as String? ?: "0.10.0"
 val junitVersion = "6.0.3"
 
 // Publish library to local Maven before running load tests:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.async-test-lib</groupId>
     <artifactId>async-test-lib</artifactId>
-    <version>0.9.0</version>
+    <version>0.10.0</version>
     <packaging>jar</packaging>
 
     <name>Async Test Library</name>


### PR DESCRIPTION
The CI Gradle workflow publishes async-test-lib:0.10.0 to local Maven via publishToMavenLocal, then runs example build.gradle.kts files that still referenced 0.9.0 — not found in local Maven (only 0.10.0) or Maven Central (not yet published).

The CI Maven workflow installs whatever version the root pom.xml declares, then runs the consumer-fixture which was already bumped to 0.10.0 — but the root pom.xml was still at 0.9.0, causing a mismatch.

Changes:
- pom.xml: bump root artifact version 0.9.0 → 0.10.0
- examples/01..10 build.gradle.kts: bump asyncTestVersion 0.9.0 → 0.10.0
- examples/01..20 pom.xml: bump async-test-lib.version 0.9.0 → 0.10.0
- examples/11..20 test source + READMEs: update version references in comments