### PR TITLE
improve: add what/why/fix structure to all detector error messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>

--- a/src/main/java/se/deversity/asynctest/diagnostics/ABAProblemDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ABAProblemDetector.java
@@ -221,7 +221,13 @@ public class ABAProblemDetector {
                 for (String cas : successfulABACases) {
                     sb.append("  - ").append(cas).append("\n");
                 }
-                sb.append("\nFix: Use AtomicStampedReference or AtomicMarkableReference\n");
+                sb.append("\nWhy: An ABA race occurs when a location holds value A, is changed to B, then changed back to A\n"
+                        + "     before a competing CAS reads it. The CAS sees A (as expected) and succeeds — but the underlying\n"
+                        + "     object may have been destroyed and recreated, or a linked list node may have been freed and\n"
+                        + "     reallocated, leaving the data structure in a corrupt state that the CAS cannot detect.\n");
+                sb.append("\nFix: Use AtomicStampedReference<V> (pairs value with an integer version stamp) or\n"
+                        + "     AtomicMarkableReference<V> (pairs value with a boolean mark) so the CAS compares both\n"
+                        + "     the value and the stamp/mark — an A→B→A cycle changes the stamp and the CAS correctly fails\n");
             }
             
             sb.append("\nWarning: ABA problems are subtle and can cause:\n");

--- a/src/main/java/se/deversity/asynctest/diagnostics/AtomicNonAtomicUpdateDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/AtomicNonAtomicUpdateDetector.java
@@ -94,8 +94,14 @@ public class AtomicNonAtomicUpdateDetector {
             StringBuilder sb = new StringBuilder("ATOMIC NON-ATOMIC UPDATE DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
             for (String d : details)    sb.append("    * ").append(d).append("\n");
-            sb.append("  Fix: replace get()+set() with a compareAndSet() CAS loop, "
-                    + "or use updateAndGet()/getAndUpdate() which handle the loop internally");
+            sb.append("  Why: A get() followed by set() on an AtomicXxx is not atomic as a compound operation — another thread\n")
+              .append("       can write a new value between the get() and the set(), and that write is silently overwritten by\n")
+              .append("       the set(). The result appears correct per-thread but loses the other thread's update entirely.\n")
+              .append("  Fix:\n")
+              .append("    - Use ref.updateAndGet(v -> v + delta) for read-modify-write on a single field\n")
+              .append("    - Use compareAndSet() in a retry loop when multiple fields must change together atomically:\n")
+              .append("        do { old = ref.get(); newVal = compute(old); } while (!ref.compareAndSet(old, newVal));\n")
+              .append("    - For pure counters, LongAdder gives better throughput under high contention");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/BlockingQueueDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/BlockingQueueDetector.java
@@ -294,7 +294,10 @@ public class BlockingQueueDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: check offer() return values, handle null from poll(), consider queue capacity");
+            sb.append("  Why: A silent offer() failure means an item was silently dropped — the producer believes it sent data but the consumer never receives it.\n" +
+                       "       An empty poll() returning null instead of blocking causes downstream logic to proceed with missing data, producing wrong results.\n" +
+                       "       Queue saturation stalls producers and can cascade into a deadlock if producers are also consumers.\n" +
+                       "  Fix: always check offer() return value; use put() to block on full queues; use take() or poll(timeout) instead of poll()");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/BoxedPrimitiveLockDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/BoxedPrimitiveLockDetector.java
@@ -106,8 +106,12 @@ public class BoxedPrimitiveLockDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("BOXED PRIMITIVE LOCK DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
-            sb.append("  Fix: use a dedicated private final Object lock = new Object() "
-                    + "instead of synchronizing on Integer, Boolean, Long, or String literals");
+            sb.append("  Why: Synchronizing on a boxed primitive (Integer, Long, Boolean) is dangerous because the JVM caches\n" +
+                       "       commonly-used values (Integers -128 to 127, Boolean.TRUE/FALSE). Two completely unrelated code paths\n" +
+                       "       that synchronize on 'Integer.valueOf(42)' acquire the same monitor object — causing accidental\n" +
+                       "       coupling and potential deadlocks with code that has nothing to do with your class.\n" +
+                       "  Fix: Always synchronize on a dedicated private final Object lock = new Object(); — never on a boxed\n" +
+                       "       primitive, String literal, or any other object that might be shared or interned by the JVM.");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/BusyWaitDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/BusyWaitDetector.java
@@ -177,7 +177,12 @@ public class BusyWaitDetector {
                     sb.append("  - ").append(loop).append('\n');
                 }
             }
-            sb.append("  Fix: replace spin loops with wait/notify, latches, or futures");
+            sb.append("\nWhy: A spin loop keeps a CPU core at 100% utilization for the entire wait duration, preventing other threads from being scheduled on that core. Under load, each spinning thread blocks a pool thread from doing real work, cascading latency across the whole system.\n");
+            sb.append("Fix: replace spin loops with blocking primitives that park the thread at zero CPU cost:\n");
+            sb.append("  - wait()/notify() inside a synchronized block (check condition in a while loop)\n");
+            sb.append("  - CountDownLatch.await() for one-time handoff\n");
+            sb.append("  - CompletableFuture.join() or Future.get() for async results\n");
+            sb.append("  - LockSupport.park() for low-level unparking by another thread");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/CacheConcurrencyDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/CacheConcurrencyDetector.java
@@ -283,7 +283,10 @@ public class CacheConcurrencyDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: use ConcurrentHashMap or synchronize cache access");
+            sb.append("  Why: Non-thread-safe caches allow concurrent reads and writes to corrupt internal state, producing stale hits,\n" +
+                       "       partially-written values, or infinite loops inside HashMap.get() under concurrent rehashing.\n" +
+                       "  Fix: replace with ConcurrentHashMap (lock-free reads, fine-grained write locks); or wrap with Collections.synchronizedMap()\n" +
+                       "       and hold the map lock for the full check-then-act sequence: synchronized(map) { if (!map.containsKey(k)) map.put(k, compute()); }");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/CalendarDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/CalendarDetector.java
@@ -228,7 +228,12 @@ public class CalendarDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: replace java.util.Calendar with java.time.* (immutable, thread-safe)");
+            sb.append("  Why: java.util.Calendar is not thread-safe. Its internal fields (year, month, day, etc.) are stored\n" +
+                       "       in a mutable instance. Concurrent use causes corrupted date computations and non-deterministic\n" +
+                       "       results — e.g. two threads formatting dates may produce dates that mix each other's day/month fields.\n" +
+                       "  Fix:\n" +
+                       "    - Replace with java.time.LocalDate, LocalDateTime, ZonedDateTime — all immutable and thread-safe\n" +
+                       "    - If Calendar is unavoidable, create a new instance per thread or use ThreadLocal<Calendar>");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/CompletableFutureChainDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/CompletableFutureChainDetector.java
@@ -287,7 +287,14 @@ public class CompletableFutureChainDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: always add .exceptionally() and ensure all futures are joined or awaited");
+            sb.append("  Why: An unjoined future whose exception is never handled silently swallows the error — the calling\n" +
+                    "       thread never sees the failure and proceeds as if the operation succeeded, producing wrong results\n" +
+                    "       or leaving the system in an inconsistent state. A future that is created but never awaited can\n" +
+                    "       also leak resources held by its computation.\n" +
+                    "  Fix:\n" +
+                    "    - Always add .exceptionally(ex -> { log(ex); return fallback; }) or .handle((r, ex) -> ...) to every chain\n" +
+                    "    - Call join() or get() on every future you submit, or compose with thenApply/thenCompose so the result propagates\n" +
+                    "    - Use CompletableFuture.allOf(futures).join() to await a collection of futures at once");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/CompletableFutureCompletionLeakDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/CompletableFutureCompletionLeakDetector.java
@@ -244,7 +244,7 @@ public class CompletableFutureCompletionLeakDetector {
             sb.append(IssueSeverity.HIGH.format())
               .append(": ")
               .append(leakedFutures.size())
-              .append(" uncompleted CompletableFuture(s) detected:\n");
+              .append(" uncompleted CompletableFuture(s) detected — any thread calling join() or get() on these will block forever; they will never be fulfilled unless explicitly completed or cancelled:\n");
 
             for (int i = 0; i < leakedFutures.size(); i++) {
                 LeakedFuture lf = leakedFutures.get(i);

--- a/src/main/java/se/deversity/asynctest/diagnostics/CompletableFutureExceptionDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/CompletableFutureExceptionDetector.java
@@ -240,7 +240,14 @@ public class CompletableFutureExceptionDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: always register .exceptionally() or .handle() for async chains");
+            sb.append("  Why: An unhandled exception in a CompletableFuture stage causes the future to complete exceptionally.\n" +
+                    "       Without .exceptionally() or .handle(), calling get()/join() will throw a wrapping ExecutionException,\n" +
+                    "       and any downstream thenApply/thenCompose stages are silently skipped, leaving the chain in an\n" +
+                    "       incomplete state with no visible error.\n" +
+                    "  Fix:\n" +
+                    "    - Add .exceptionally(ex -> fallbackValue) to recover from errors in the chain\n" +
+                    "    - Use .handle((result, ex) -> ...) when you need to inspect both success and failure in one place\n" +
+                    "    - Call get() inside a try/catch ExecutionException so failures surface immediately");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/ConcurrentMapComputeRecursionDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ConcurrentMapComputeRecursionDetector.java
@@ -81,9 +81,13 @@ public class ConcurrentMapComputeRecursionDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("CONCURRENT MAP COMPUTE RECURSION DETECTED:\n");
             for (String r : recursions) sb.append("  - ").append(r).append("\n");
-            sb.append("  Fix: avoid calling compute*() on the same map inside a compute*() "
-                    + "mapping function for the same key; use a separate helper map "
-                    + "or restructure the recursion to avoid re-entry");
+            sb.append("  Why: ConcurrentHashMap.compute() locks the bucket for the key while invoking the mapping function.\n" +
+                       "       If the mapping function calls compute() on the same map for the same key, it tries to re-acquire\n" +
+                       "       the already-held bucket lock — the thread deadlocks indefinitely against itself.\n" +
+                       "  Fix:\n" +
+                       "    - Restructure the algorithm to avoid re-entrant compute() on the same key\n" +
+                       "    - Compute the new value first (in a local variable), then call map.put(key, value) atomically\n" +
+                       "    - For recursive structures, use a separate auxiliary map or a stack-based approach");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/ConcurrentModificationDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ConcurrentModificationDetector.java
@@ -255,7 +255,11 @@ public class ConcurrentModificationDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: use Iterator.remove() for safe removal during iteration, or use thread-safe collections");
+            sb.append("  Why: Non-thread-safe collections track a modCount internally. Any structural change (add/remove) while another thread\n" +
+                       "       is iterating increments modCount, causing the iterator to throw ConcurrentModificationException or silently skip elements.\n" +
+                       "  Fix:\n" +
+                       "    - Remove during iteration via iterator.remove() (single-threaded) or Iterator from a synchronized block (multi-threaded)\n" +
+                       "    - Replace with CopyOnWriteArrayList (iteration sees a stable snapshot) or ConcurrentHashMap for map use-cases");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/ConditionVariableDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ConditionVariableDetector.java
@@ -254,7 +254,13 @@ public class ConditionVariableDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: use while-loop for await(), ensure signal() follows state change");
+            sb.append("  Why: A signal() sent before await() is called is lost — the waiting thread will never see it and\n" +
+"     blocks indefinitely. Checking a condition only once (if instead of while) causes spurious-wakeup\n" +
+"     bugs where the thread proceeds even though the condition is not yet true.\n" +
+"  Fix:\n" +
+"    - Always await() in a while loop: while (!ready) { condition.await(); }\n" +
+"    - Signal after the state change, not before: ready = true; condition.signalAll();\n" +
+"    - Prefer signalAll() over signal() unless exactly one thread should wake, to avoid missed-signal bugs");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/CopyOnWriteCollectionDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/CopyOnWriteCollectionDetector.java
@@ -186,7 +186,13 @@ public class CopyOnWriteCollectionDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: use ConcurrentHashMap.newKeySet() or ConcurrentLinkedQueue for write-heavy workloads");
+            sb.append("  Why: Every add/remove on a CopyOnWrite collection creates a full copy of the underlying array.\n" +
+                       "       Under write-heavy load this means O(n) allocation per write, excessive GC pressure, and\n" +
+                       "       throughput that degrades proportionally to collection size — exactly the wrong trade-off for frequent writes.\n" +
+                       "  Fix:\n" +
+                       "    - Write-heavy sets: ConcurrentHashMap.newKeySet() (O(1) amortised writes)\n" +
+                       "    - Write-heavy queues: ConcurrentLinkedQueue or a BlockingQueue variant\n" +
+                       "    - CopyOnWrite is only appropriate when reads vastly outnumber writes (e.g. listener lists)");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/CountDownLatchDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/CountDownLatchDetector.java
@@ -101,7 +101,9 @@ public class CountDownLatchDetector {
                       .append(" (expected ").append(info.initialCount)
                       .append(" countDown() calls, but await() timed out)\n");
                 }
-                sb.append("  Fix: Ensure all threads call countDown() before await() timeout\n");
+                sb.append("  Why: If countDown() is not called enough times the latch count never reaches zero and await() blocks forever;\n");
+                sb.append("       the test or application hangs waiting for threads that never signal completion.\n");
+                sb.append("  Fix: Ensure every participating thread calls countDown() exactly once — even on exception paths (use try/finally)\n");
             }
 
             if (!extraCountDownLatches.isEmpty()) {
@@ -112,7 +114,9 @@ public class CountDownLatchDetector {
                       .append(" (initial count: ").append(info.initialCount)
                       .append(", but countDown() called more times)\n");
                 }
-                sb.append("  Fix: Verify countDown() is called exactly once per thread\n");
+                sb.append("  Why: Calling countDown() more times than the initial count has no effect (the latch stays at zero),\n");
+                sb.append("       but it indicates a logic error in thread coordination that can mask real bugs.\n");
+                sb.append("  Fix: Verify countDown() is called exactly once per thread — track with an AtomicInteger if needed\n");
             }
 
             if (!hasIssues()) {

--- a/src/main/java/se/deversity/asynctest/diagnostics/CyclicBarrierDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/CyclicBarrierDetector.java
@@ -105,7 +105,9 @@ public class CyclicBarrierDetector {
                       .append(" (").append(info.parties).append(" parties expected, ")
                       .append(info.arrivals).append(" arrived before timeout)\n");
                 }
-                sb.append("  Fix: Ensure all threads reach the barrier before timeout\n");
+                sb.append("  Why: If fewer threads than expected call await(), the barrier never trips and all waiting threads block indefinitely.\n");
+                sb.append("       Once a barrier is broken, it propagates BrokenBarrierException to all waiting parties.\n");
+                sb.append("  Fix: Ensure all registered parties call await(); wrap in try-catch BrokenBarrierException and reset() before reuse\n");
             }
 
             if (!brokenBarriers.isEmpty()) {
@@ -115,7 +117,9 @@ public class CyclicBarrierDetector {
                     sb.append("    - ").append(info.name)
                       .append(" (barrier broken - thread interrupted or timed out)\n");
                 }
-                sb.append("  Fix: Handle BrokenBarrierException and InterruptedException properly\n");
+                sb.append("  Why: A thread timing out or being interrupted breaks the barrier for all other waiting parties,\n");
+                sb.append("       leaving them stuck unless the barrier is explicitly reset.\n");
+                sb.append("  Fix: Catch BrokenBarrierException, call barrier.reset() before reuse, and restore interrupt status on InterruptedException\n");
             }
 
             if (!hasIssues()) {

--- a/src/main/java/se/deversity/asynctest/diagnostics/DeprecatedThreadApiDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/DeprecatedThreadApiDetector.java
@@ -83,9 +83,13 @@ public class DeprecatedThreadApiDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("DEPRECATED THREAD API USAGE DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
-            sb.append("  Fix: replace Thread.stop() with cooperative cancellation via a "
-                    + "volatile flag or interruption; replace Thread.suspend/resume() with "
-                    + "wait/notify or a Semaphore; these APIs are removed in Java 20+");
+            sb.append("  Why: Thread.stop(), Thread.suspend(), and Thread.resume() are permanently deprecated because they are\n" +
+                       "       fundamentally unsafe. stop() kills the thread mid-execution, leaving shared objects in a\n" +
+                       "       partially-updated, corrupt state. suspend() holds the thread's locks while suspended, causing\n" +
+                       "       deadlocks. These APIs should never appear in production or test code.\n" +
+                       "  Fix: Replace Thread.stop() with a cooperative shutdown: set a volatile boolean stop flag and have the\n" +
+                       "       thread check it regularly: while (!stopped) { doWork(); }\n" +
+                       "       Replace suspend()/resume() with wait()/notify() or Condition.await()/signalAll() for controlled pausing.");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/ExchangerDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ExchangerDetector.java
@@ -114,8 +114,10 @@ public class ExchangerDetector {
                     sb.append("    - ").append(info.name)
                       .append(" (exchange timed out - no partner thread found)\n");
                 }
-                sb.append("  Fix: Ensure even number of threads call exchange()\n");
-                sb.append("  Or use exchange(value, timeout, unit) with proper timeout handling\n");
+                sb.append("  Why: Exchanger requires exactly two threads to rendezvous simultaneously. If one thread times out or is\n");
+                sb.append("       interrupted, the corresponding thread waits forever for a partner that will never arrive.\n");
+                sb.append("  Fix: Ensure an even number of threads always call exchange(); use exchange(value, timeout, unit) and handle\n");
+                sb.append("       TimeoutException so the orphaned thread does not block indefinitely\n");
             }
 
             if (!interruptedExchangers.isEmpty()) {
@@ -125,7 +127,9 @@ public class ExchangerDetector {
                     sb.append("    - ").append(info.name)
                       .append(" (exchange interrupted)\n");
                 }
-                sb.append("  Fix: Handle InterruptedException properly and restore interrupt status\n");
+                sb.append("  Why: Swallowing InterruptedException leaves the interrupt flag cleared, silently preventing shutdown signals\n");
+                sb.append("       from propagating up the call stack.\n");
+                sb.append("  Fix: Restore the interrupt flag (Thread.currentThread().interrupt()) and rethrow or handle the interruption\n");
             }
 
             if (nullValueExchanges > 0) {

--- a/src/main/java/se/deversity/asynctest/diagnostics/ExecutorShutdownDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ExecutorShutdownDetector.java
@@ -132,8 +132,14 @@ public class ExecutorShutdownDetector {
             StringBuilder sb = new StringBuilder("EXECUTOR SHUTDOWN ISSUES DETECTED:\n");
             for (String issue : notShutDown)        sb.append("  - ").append(issue).append("\n");
             for (String issue : noAwaitTermination) sb.append("  - ").append(issue).append("\n");
-            sb.append("  Fix: always call shutdown() followed by awaitTermination() "
-                    + "to ensure a clean executor lifecycle and prevent thread leaks");
+            sb.append("  Why: An executor that is never shut down keeps its worker threads alive indefinitely. Those threads\n" +
+                    "       are non-daemon by default, so they prevent JVM exit and consume OS thread resources. Without\n" +
+                    "       awaitTermination(), in-flight tasks may be interrupted mid-execution when the test ends, causing\n" +
+                    "       partial writes, corrupted state, or misleading test failures.\n" +
+                    "  Fix:\n" +
+                    "    - Always call shutdown() then awaitTermination(timeout, unit) in a finally block\n" +
+                    "    - Java 19+: ExecutorService implements AutoCloseable — use try-with-resources for automatic shutdown\n" +
+                    "    - Use shutdownNow() only when you need to cancel in-flight tasks; handle the returned pending-task list");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/ExplicitGcDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ExplicitGcDetector.java
@@ -74,8 +74,13 @@ public class ExplicitGcDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("EXPLICIT GC INVOCATION DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
-            sb.append("  Fix: remove explicit System.gc() / Runtime.gc() calls; "
-                    + "rely on the JVM's automatic GC policy instead");
+            sb.append("  Why: System.gc() is a hint to the JVM to run a full GC cycle. In a concurrent test, it pauses all\n" +
+                       "       application threads (stop-the-world), distorting timing measurements and causing spurious failures\n" +
+                       "       in latency-sensitive tests. It also interferes with WeakReference-based caches, potentially\n" +
+                       "       evicting entries that should still be live.\n" +
+                       "  Fix: Remove System.gc() calls from production and test code. If you need to trigger GC for a\n" +
+                       "       WeakReference test, use a dedicated test helper that allocates memory until a GC is forced\n" +
+                       "       rather than calling System.gc() directly.");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/FalseSharingDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/FalseSharingDetector.java
@@ -224,16 +224,20 @@ public class FalseSharingDetector {
                         pair.field1, pair.accesses1, pair.field2, pair.accesses2, pair.distanceInBytes
                     ));
                 }
-                sb.append("\nFix: Add @Contended annotation or adjust field layout\n");
             }
-            
+
             if (!highContentionFields.isEmpty()) {
-                sb.append("\nHigh-contention fields (potential false sharing):\n");
+                sb.append("\nHigh-contention fields accessed by multiple threads:\n");
                 for (String field : highContentionFields) {
                     sb.append("  - ").append(field).append("\n");
                 }
-                sb.append("\nFix: Pad fields or use @Contended\n");
             }
+
+            sb.append("\nWhy: CPUs transfer memory in 64-byte cache lines. When Thread A writes fieldA and Thread B writes fieldB and both fields occupy the same cache line, every write forces the entire line to be invalidated and re-fetched across all cores — \"cache ping-pong\" that can reduce throughput by 10x even though the threads are touching entirely different fields.\n");
+            sb.append("Fix:\n");
+            sb.append("  - Annotate each hot field with @Contended (sun.misc.Contended / jdk.internal.vm.annotation.Contended); add -XX:+EnableContended on Java 8-10 (default from Java 11 onward)\n");
+            sb.append("  - Pad manually: place 7 long dummy fields between the hot fields to force them onto separate cache lines\n");
+            sb.append("  - Redesign: group read-only fields together and isolate write-heavy fields in their own inner class annotated @Contended");
             
             return sb.toString();
         }

--- a/src/main/java/se/deversity/asynctest/diagnostics/ForkJoinPoolDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ForkJoinPoolDetector.java
@@ -128,9 +128,11 @@ public class ForkJoinPoolDetector {
                     sb.append("    - ").append(taskInfo).append("\n");
                 }
                 sb.append("  Problem: Forked tasks must be joined to get results and exceptions\n");
-                sb.append("  Fix: Always call join() after fork():\n");
-                sb.append("    task.fork();\n");
-                sb.append("    result = task.join();\n");
+                sb.append("  Why: fork() submits the task asynchronously but does not wait for it. Without join(), the task result\n" +
+                        "       is discarded and any exception it throws is silently lost. The parent task proceeds with a missing\n" +
+                        "       or default value, producing silently wrong computation results.\n");
+                sb.append("  Fix: Always call join() after fork() to retrieve the result and propagate exceptions:\n");
+                sb.append("    task.fork(); result = task.join();  // or: result = task.invoke() (fork + join in one call)\n");
             }
 
             if (!exceptionsInTasks.isEmpty()) {
@@ -138,7 +140,9 @@ public class ForkJoinPoolDetector {
                 for (String taskInfo : exceptionsInTasks) {
                     sb.append("    - ").append(taskInfo).append("\n");
                 }
-                sb.append("  Fix: Handle exceptions in compute() method\n");
+                sb.append("  Why: An uncaught exception in compute() propagates to the join() caller as an unchecked RuntimeException.\n" +
+                        "       If join() is never called (leaked fork), the exception is silently dropped.\n");
+                sb.append("  Fix: Wrap the body of compute() in try/catch and either handle the exception or rethrow as RuntimeException\n");
             }
 
             if (taskStealCount > 0) {

--- a/src/main/java/se/deversity/asynctest/diagnostics/FutureBlockingDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/FutureBlockingDetector.java
@@ -106,7 +106,14 @@ public class FutureBlockingDetector {
             for (String issue : starvationRisks) {
                 sb.append("  - ").append(issue).append('\n');
             }
-            sb.append("  Fix: avoid blocking get()/join() on tasks scheduled to the same bounded executor");
+            sb.append("  Why: A thread calling Future.get() or CompletableFuture.join() blocks until the task completes.\n" +
+                       "       If the task was submitted to the same bounded executor whose thread is now blocked, the\n" +
+                       "       executor has one fewer available thread. When all threads are blocked waiting for queued\n" +
+                       "       tasks, those tasks can never run — the executor is deadlocked.\n" +
+                       "  Fix:\n" +
+                       "    - Submit blocking-wait tasks to a different (unbounded or larger) executor\n" +
+                       "    - Use non-blocking composition instead: thenApply/thenCompose instead of get()/join()\n" +
+                       "    - For virtual threads: blocking inside a virtual thread is safe — there is no pool exhaustion");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/FutureIgnoredDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/FutureIgnoredDetector.java
@@ -96,9 +96,12 @@ public class FutureIgnoredDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("IGNORED FUTURE DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
-            sb.append("  Fix: always call future.get() (or at least future.isDone()) to "
-                    + "retrieve exceptions; alternatively use CompletableFuture with "
-                    + "exceptionally()/whenComplete() to handle failures asynchronously");
+            sb.append("  Why: A Future that is submitted but never retrieved (get()/join() never called) means the task runs\n" +
+                       "       fire-and-forget. Exceptions thrown by the task are silently swallowed — the calling thread never\n" +
+                       "       knows the task failed. The result is also discarded, hiding data-processing errors.\n" +
+                       "  Fix: Always retrieve Future results: call get() or join(), or chain with thenApply/thenAccept/exceptionally.\n" +
+                       "       If fire-and-forget is intentional, at least register an exception handler:\n" +
+                       "       future.exceptionally(ex -> { log(ex); return null; });");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/HttpClientConcurrencyDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/HttpClientConcurrencyDetector.java
@@ -262,7 +262,13 @@ public class HttpClientConcurrencyDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: ensure all HTTP requests are properly completed and responses are consumed/closed");
+            sb.append("  Why: An HTTP request that is sent but never completed (response not read/closed) holds an open\n" +
+                       "       connection in the connection pool. Under sustained leaking, the pool exhausts its connection\n" +
+                       "       limit and all subsequent requests block indefinitely waiting for a free connection.\n" +
+                       "  Fix:\n" +
+                       "    - Always close the response body: use try-with-resources on HttpResponse.body() or call close()\n" +
+                       "    - For async requests: always call join() or thenAccept() to consume the response\n" +
+                       "    - Set a connection pool limit and a response timeout so hung requests time out rather than block forever");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/InheritableThreadLocalMisuseDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/InheritableThreadLocalMisuseDetector.java
@@ -151,8 +151,14 @@ public class InheritableThreadLocalMisuseDetector {
             for (String issue : pooledGetIssues)   sb.append("  - ").append(issue).append("\n");
             for (String issue : pooledSetIssues)   sb.append("  - ").append(issue).append("\n");
             for (String issue : multiThreadAccess) sb.append("  - ").append(issue).append("\n");
-            sb.append("  Fix: use ScopedValue (Java 21+) or pass context explicitly; "
-                    + "never rely on InheritableThreadLocal in thread-pool code");
+            sb.append("  Why: InheritableThreadLocal copies values at thread-creation time, not at task-submission time.\n" +
+                    "       In a thread pool the threads are created once at pool startup, so every task inherits the\n" +
+                    "       creator's context from that point — not the submitter's current context. This causes stale or\n" +
+                    "       cross-task context contamination that is extremely hard to reproduce.\n" +
+                    "  Fix:\n" +
+                    "    - Pass context explicitly as a method parameter or embed it in the task object\n" +
+                    "    - Use ScopedValue (Java 21+) with ScopedValue.where(KEY, value).run(task) — inherits correctly per call\n" +
+                    "    - If InheritableThreadLocal is unavoidable, wrap submissions to copy the value into the task closure");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/InterruptSwallowingDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/InterruptSwallowingDetector.java
@@ -85,9 +85,13 @@ public class InterruptSwallowingDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("INTERRUPT SWALLOWING DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
-            sb.append("  Fix: in every catch(InterruptedException) block either rethrow "
-                    + "the exception or call Thread.currentThread().interrupt() to preserve "
-                    + "the interrupt signal for callers");
+            sb.append("  Why: Catching InterruptedException and not restoring the interrupt flag clears the thread's interrupted\n" +
+                       "       status permanently. Any code up the call stack that checks Thread.interrupted() or calls another\n" +
+                       "       blocking method expecting to be interruptible will never see the interrupt — the shutdown signal\n" +
+                       "       is silently swallowed, preventing graceful termination.\n" +
+                       "  Fix: Always restore the interrupt flag when catching InterruptedException:\n" +
+                       "       catch (InterruptedException e) { Thread.currentThread().interrupt(); throw new RuntimeException(e); }\n" +
+                       "       Or rethrow InterruptedException directly if the method signature allows it.");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/LatchMisuseDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/LatchMisuseDetector.java
@@ -98,7 +98,14 @@ public class LatchMisuseDetector {
             for (String issue : extraCountDowns) {
                 sb.append("  - ").append(issue).append('\n');
             }
-            sb.append("  Fix: ensure every await path has matching countDown() completion paths");
+            sb.append("  Why: If countDown() is called fewer times than await() needs, the latch count never reaches zero\n" +
+"       and await() blocks indefinitely — the test or downstream logic hangs silently.\n" +
+"       Calling countDown() more times than the initial count is a no-op after zero but indicates\n" +
+"       a logic error in how threads are coordinated.\n" +
+"  Fix:\n" +
+"    - Ensure every thread that participates in the latch calls countDown() exactly once, even on exception paths\n" +
+"    - Use try/finally to guarantee countDown() is called: try { doWork(); } finally { latch.countDown(); }\n" +
+"    - Prefer CompletableFuture or CyclicBarrier when the one-shot guarantee of CountDownLatch is not needed");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/LivelockDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/LivelockDetector.java
@@ -207,7 +207,22 @@ public class LivelockDetector {
                     sb.append("  - ").append(thread).append("\n");
                 }
             }
-            
+
+            sb.append("\nWhy: ");
+            if (!livelockCandidates.isEmpty()) {
+                sb.append("Livelock threads appear active (CPU time accumulates) but make no real progress — they keep reacting to each other's state changes in a tight cycle, burning CPU indefinitely without completing any work. ");
+            }
+            if (!starvedThreads.isEmpty()) {
+                sb.append("Starved threads are permanently blocked or never scheduled because other threads monopolize CPU or locks, causing tasks to silently stall or never execute. ");
+            }
+            if (!noProgressThreads.isEmpty()) {
+                sb.append("Threads with no progress are neither completing work nor making forward state changes — a sign of an unnoticed block or incorrect loop condition. ");
+            }
+            sb.append("\nFix:\n");
+            sb.append("  - Livelock: introduce randomised back-off between retries — e.g. Thread.sleep(ThreadLocalRandom.current().nextInt(10, 50)) — so threads yield to each other rather than thrashing in lock-step\n");
+            sb.append("  - Starvation: use a fair lock (new ReentrantLock(true)) so threads acquire in arrival order; reduce lock hold time; avoid priority inversion\n");
+            sb.append("  - No-progress threads: check for missed notify() calls, broken loop exit conditions, or tasks submitted to a saturated executor");
+
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/LockContentionDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/LockContentionDetector.java
@@ -176,8 +176,14 @@ public class LockContentionDetector {
                 sb.append("  No contention issues detected.\n");
             }
 
-            sb.append("  Fix: reduce critical-section size, use finer-grained locks,")
-              .append(" lock striping, or lock-free data structures (AtomicXxx, ConcurrentHashMap).");
+            sb.append("  Why: High contention means threads spend most of their time blocked waiting to acquire the lock rather than doing real work.\n")
+              .append("       Beyond the performance hit, extreme contention can starve low-priority threads indefinitely if the JVM's lock-scheduling\n")
+              .append("       is non-fair — tasks queue up faster than they are released.\n")
+              .append("  Fix:\n")
+              .append("    - Reduce the critical section to the minimum work that truly needs exclusive access\n")
+              .append("    - Use finer-grained locks: split one coarse-grained lock into per-key or per-segment locks\n")
+              .append("    - Use lock striping (e.g. Guava's Striped<Lock>) to limit contention to a small set of buckets\n")
+              .append("    - Replace locks with lock-free structures: AtomicLong.incrementAndGet(), ConcurrentHashMap.compute()");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/LockDowngradeDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/LockDowngradeDetector.java
@@ -147,8 +147,13 @@ public class LockDowngradeDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("LOCK UPGRADE/DOWNGRADE ISSUES DETECTED:\n");
             for (String issue : upgradeAttempts) sb.append("  - ").append(issue).append("\n");
-            sb.append("  Fix: ReentrantReadWriteLock does not support read→write upgrade.\n");
-            sb.append("  For downgrade: acquire read lock while holding write lock, then release write lock.");
+            sb.append("  Why: ReentrantReadWriteLock does not support upgrade (read→write). A thread holding a read lock that\n" +
+"       tries to acquire the write lock will deadlock against itself, since the write lock requires all\n" +
+"       read locks to be released first — including its own.\n" +
+"  Fix:\n" +
+"    - To upgrade: release the read lock, then acquire the write lock (re-validate the condition after)\n" +
+"    - For safe downgrade: acquire the read lock while still holding the write lock, THEN release the write lock\n" +
+"    - Consider StampedLock.tryConvertToWriteLock(stamp) if upgrade is a frequent pattern");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/LockLeakDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/LockLeakDetector.java
@@ -230,7 +230,13 @@ public class LockLeakDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: always use try { lock.lock(); } finally { lock.unlock(); } pattern");
+            sb.append("  Why: An unreleased lock blocks every other thread that tries to acquire it — they wait indefinitely,\n" +
+"       causing the test or application to hang. Even a single missed unlock in an exception path is enough\n" +
+"       to starve all contenders for that lock.\n" +
+"  Fix:\n" +
+"    - Always wrap lock usage in try/finally: lock.lock(); try { ... } finally { lock.unlock(); }\n" +
+"    - For scoped locking, use a helper: try (var l = new AutoUnlock(lock)) { ... }\n" +
+"    - Prefer synchronized blocks for simple cases — the JVM guarantees unlock on exit");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/MdcContextLeakDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/MdcContextLeakDetector.java
@@ -100,8 +100,13 @@ public class MdcContextLeakDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("MDC CONTEXT LEAK DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
-            sb.append("  Fix: call MDC.clear() (or MDC.remove(key) for each key added) "
-                    + "in a finally block to prevent leakage to pooled-thread reuse");
+            sb.append("  Why: SLF4J's MDC (Mapped Diagnostic Context) is stored in a ThreadLocal. In a thread pool, a thread\n" +
+                       "       that sets MDC keys and never clears them contaminates the next task running on that thread with\n" +
+                       "       stale context. Log entries from Task B then carry Task A's request ID, user, or tenant — a\n" +
+                       "       data-leakage and mis-attribution bug.\n" +
+                       "  Fix: Always clear MDC in a task-finally block:\n" +
+                       "       try { MDC.put(\"requestId\", id); doWork(); } finally { MDC.clear(); }\n" +
+                       "       Or clear only specific keys: finally { MDC.remove(\"requestId\"); }");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/MissedSignalDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/MissedSignalDetector.java
@@ -168,9 +168,15 @@ public class MissedSignalDetector {
                 sb.append("  No missed signals detected.\n");
             }
 
-            sb.append("  Fix: always check a state predicate in a loop before waiting")
-              .append(" (while (!ready) { monitor.wait(); }) so that re-checking after the fact")
-              .append(" handles signals that arrive before wait().");
+            sb.append("  Why: A notify() that fires before wait() is called is silently lost — the waiting thread never wakes.\n" +
+"     This is the \"missed signal\" (or \"lost wakeup\") problem. Without a state predicate loop, the\n" +
+"     thread waits forever even though the condition it was waiting for has already become true.\n" +
+"  Fix:\n" +
+"    - Always guard wait() with a state predicate in a while loop:\n" +
+"        synchronized(lock) { while (!ready) { lock.wait(); } }\n" +
+"    - The while loop re-checks the condition after every wakeup, so a signal that arrives before wait()\n" +
+"      is handled correctly — the thread checks the condition, sees it is true, and skips wait() entirely\n" +
+"    - Use notifyAll() instead of notify() to avoid leaving other waiters stranded");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/MutableMapKeyDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/MutableMapKeyDetector.java
@@ -130,8 +130,12 @@ public class MutableMapKeyDetector {
                 sb.append("  Mutation details:\n");
                 for (String detail : mutationDetails) sb.append("    * ").append(detail).append("\n");
             }
-            sb.append("  Fix: use only immutable objects as Map/Set keys, "
-                    + "or restrict hashCode/equals to final fields");
+            sb.append("  Why: HashMap/HashSet locate an entry by computing hashCode() and comparing equals() on the key.\n" +
+                       "       If the key object is mutated after insertion its hashCode changes, so the map looks in the wrong bucket\n" +
+                       "       and cannot find the entry — lookups silently return null, and remove() silently does nothing.\n" +
+                       "  Fix:\n" +
+                       "    - Use only immutable types as keys (String, Integer, UUID, value records)\n" +
+                       "    - If a mutable key is unavoidable, base hashCode/equals solely on final fields that never change after construction");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/NestedMonitorLockoutDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/NestedMonitorLockoutDetector.java
@@ -105,8 +105,15 @@ public class NestedMonitorLockoutDetector {
             StringBuilder sb = new StringBuilder("NESTED MONITOR LOCKOUT ISSUES DETECTED:\n");
             Set<String> deduped = new LinkedHashSet<>(incidents);
             for (String incident : deduped) sb.append("  - ").append(incident).append("\n");
-            sb.append("  Fix: never hold a monitor while calling wait(), Future.get(), Lock.lock(),"
-                    + " or other blocking operations on a different object's monitor");
+            sb.append("  Why: When a thread holds Monitor A and then calls a blocking operation that waits for Monitor B,\n")
+              .append("       every thread that needs Monitor A is forced to wait for the unrelated blocking call to complete —\n")
+              .append("       even though the blocking call has nothing to do with the state protected by Monitor A.\n")
+              .append("       If Monitor B is also contested, this creates a layered wait chain that degrades to a near-deadlock.\n")
+              .append("  Fix:\n")
+              .append("    - Release the monitor before any blocking call: copy the data you need under the lock, exit the\n")
+              .append("      synchronized block, then perform the blocking operation outside\n")
+              .append("    - Use Condition.await() (from ReentrantLock) instead of Object.wait() — it releases the associated\n")
+              .append("      lock atomically while waiting, so other threads can enter the critical section");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/OptimisticReadValidationDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/OptimisticReadValidationDetector.java
@@ -113,8 +113,13 @@ public class OptimisticReadValidationDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("OPTIMISTIC READ VALIDATION ISSUE DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
-            sb.append("  Fix: always call lock.validate(stamp) before using optimistically-read data; "
-                    + "if validation fails, re-read under a full read or write lock");
+            sb.append("  Why: StampedLock's optimistic read acquires no lock, so a concurrent writer may update shared fields\n" +
+                       "       between the read and the validate() call. The read values are then a torn snapshot — some fields\n" +
+                       "       from before the write and some from after — producing silently wrong computation results.\n" +
+                       "  Fix: always call lock.validate(stamp) before using optimistically-read data;\n" +
+                       "       if validation fails, re-read under a full read lock:\n" +
+                       "       long stamp = lock.tryOptimisticRead(); int v = field;\n" +
+                       "       if (!lock.validate(stamp)) { stamp = lock.readLock(); try { v = field; } finally { lock.unlockRead(stamp); } }");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/ParallelStreamDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ParallelStreamDetector.java
@@ -271,7 +271,15 @@ public class ParallelStreamDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: use stateless lambdas, thread-safe collectors, avoid side effects");
+            sb.append("  Why: Parallel stream operations distribute work across multiple threads on the common ForkJoinPool.\n"
+                    + "       Stateful lambdas, mutable shared state, and side effects inside stream operations are interleaved\n"
+                    + "       without ordering guarantees, producing non-deterministic results, silent data corruption, and\n"
+                    + "       interference with other parallel streams running in the same JVM.\n"
+                    + "  Fix:\n"
+                    + "    - Write stateless lambdas that depend only on their input and produce a return value\n"
+                    + "    - Use thread-safe collectors: Collectors.toConcurrentMap(), Collectors.groupingByConcurrent()\n"
+                    + "    - Avoid side effects (writing to external lists/maps/files) inside stream operations\n"
+                    + "    - If side effects are unavoidable, use a sequential stream or synchronize the shared target");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/PhaserDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/PhaserDetector.java
@@ -116,7 +116,9 @@ public class PhaserDetector {
                       .append(" (").append(info.parties).append(" parties expected, ")
                       .append(info.arrivals).append(" arrived)\n");
                 }
-                sb.append("  Fix: Ensure all threads call arrive/awaitAdvance before timeout\n");
+                sb.append("  Why: A Phaser advances only when all registered parties arrive. If any party never calls arrive() or arriveAndAwaitAdvance(),\n");
+                sb.append("       all other parties block at the phase boundary indefinitely — the phaser stalls forever.\n");
+                sb.append("  Fix: Ensure every registered party always arrives (even on exception paths); use try/finally or deregister with arriveAndDeregister()\n");
             }
 
             if (!terminatedPhasers.isEmpty()) {
@@ -126,7 +128,9 @@ public class PhaserDetector {
                     sb.append("    - ").append(info.name)
                       .append(" (phaser terminated - possibly due to timeout or unbalance)\n");
                 }
-                sb.append("  Fix: Check for phaser.unbalance() calls or timeout conditions\n");
+                sb.append("  Why: A terminated Phaser rejects all further arrive/await calls, causing threads that still need to\n");
+                sb.append("       synchronise to receive an unexpected terminated-state response.\n");
+                sb.append("  Fix: Check phaser.isTerminated() before registering or arriving; investigate unintended arriveAndDeregister() calls\n");
             }
 
             if (!hasIssues()) {

--- a/src/main/java/se/deversity/asynctest/diagnostics/RaceConditionDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/RaceConditionDetector.java
@@ -221,7 +221,7 @@ public class RaceConditionDetector {
 
             StringBuilder sb = new StringBuilder();
             sb.append(IssueSeverity.HIGH.format())
-              .append(": Potential race conditions detected\n\n");
+              .append(": Potential race conditions detected — unsynchronized writes to shared fields allow threads to overwrite each other's changes, producing lost updates, stale reads, and silently wrong results\n\n");
 
             if (!potentialRaces.isEmpty()) {
                 sb.append("Concurrent write hotspots:\n");

--- a/src/main/java/se/deversity/asynctest/diagnostics/ReentrantLockDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ReentrantLockDetector.java
@@ -105,7 +105,11 @@ public class ReentrantLockDetector {
                     sb.append("    - ").append(info.name)
                       .append(" (tryLock() timed out)\n");
                 }
-                sb.append("  Fix: Increase timeout or review lock contention\n");
+                sb.append("  Why: tryLock() timing out means the lock is held for longer than expected, often indicating an\n" +
+"       undersized timeout, a lock held during slow I/O, or genuine contention from too many threads.\n" +
+"       Silently proceeding without the lock leads to data races or skipped critical sections.\n" +
+"  Fix: Increase the timeout, reduce the critical section size, or switch to a blocking lock.lock()\n" +
+"       if the caller must wait; never ignore a failed tryLock() — always handle the false return\n");
             }
 
             if (!starvationThreads.isEmpty()) {
@@ -113,7 +117,10 @@ public class ReentrantLockDetector {
                 for (String threadInfo : starvationThreads) {
                     sb.append("    - Thread ").append(threadInfo).append("\n");
                 }
-                sb.append("  Fix: Consider using fair ReentrantLock or reduce lock hold time\n");
+                sb.append("  Why: A non-fair lock allows new threads to \"barge\" ahead of waiting threads, causing some threads\n" +
+"       to wait arbitrarily long or never acquire the lock at all.\n" +
+"  Fix: Construct with new ReentrantLock(true) for FIFO fairness; or reduce lock hold time so all\n" +
+"       threads get more opportunities to acquire it\n");
             }
 
             if (!hasIssues()) {

--- a/src/main/java/se/deversity/asynctest/diagnostics/ResourceLeakDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ResourceLeakDetector.java
@@ -205,7 +205,14 @@ public class ResourceLeakDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: use try-with-resources or close in finally block");
+            sb.append("  Why: Resources such as streams, connections, and file handles consume OS-level file descriptors.\n" +
+"       An unclosed resource leaks the descriptor for the lifetime of the process. Under sustained load,\n" +
+"       leaked descriptors exhaust the OS limit (typically 1024–65535 per process) and all subsequent\n" +
+"       open() calls fail with \"Too many open files\".\n" +
+"  Fix:\n" +
+"    - Use try-with-resources for any AutoCloseable: try (InputStream in = ...) { ... }\n" +
+"    - If try-with-resources is not possible, call close() in a finally block\n" +
+"    - Verify every code path (including exception paths) closes the resource");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/ScheduledExecutorDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ScheduledExecutorDetector.java
@@ -138,8 +138,9 @@ public class ScheduledExecutorDetector {
                     ExecutorInfo info = executorRegistry.get(executor);
                     sb.append("    - ").append(info.name).append("\n");
                 }
-                sb.append("  Fix: Always call shutdown() or shutdownNow() after use\n");
-                sb.append("  Or use try-with-resources pattern\n");
+                sb.append("  Why: A ScheduledExecutorService that is never shut down continues scheduling tasks forever and\n" +
+                        "       keeps its worker threads alive, preventing JVM exit and leaking OS thread resources.\n");
+                sb.append("  Fix: Always call shutdown() or shutdownNow() in a finally block; Java 19+: use try-with-resources\n");
             }
 
             if (!longRunningTasks.isEmpty()) {
@@ -152,7 +153,10 @@ public class ScheduledExecutorDetector {
 
             if (exceptionInTasks > 0) {
                 sb.append("  Exceptions in Scheduled Tasks: ").append(exceptionInTasks).append("\n");
-                sb.append("  Fix: Handle exceptions in scheduled tasks to prevent cancellation\n");
+                sb.append("  Why: ScheduledExecutorService silently cancels a recurring task if its Runnable throws an unchecked exception.\n" +
+                        "       The task simply stops running with no log entry or notification — a critical background job can\n" +
+                        "       vanish unnoticed.\n");
+                sb.append("  Fix: Wrap the task body in try/catch Throwable: () -> { try { work(); } catch (Throwable t) { log(t); } }\n");
             }
 
             if (!hasIssues()) {

--- a/src/main/java/se/deversity/asynctest/diagnostics/SemaphoreMisuseDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/SemaphoreMisuseDetector.java
@@ -218,7 +218,14 @@ public class SemaphoreMisuseDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: ensure every acquire() has a matching release() in a finally block");
+            sb.append("  Why: A permit that is acquired but never released is permanently consumed — the semaphore's available\n" +
+"       count drops by one for every leak. Under sustained leaking, all permits are exhausted and every\n" +
+"       subsequent acquire() blocks forever, halting all threads that depend on the semaphore.\n" +
+"       Over-releasing is equally wrong: it inflates the permit count beyond the intended limit, allowing\n" +
+"       more concurrent access than the resource can safely handle.\n" +
+"  Fix:\n" +
+"    - Always pair acquire() with release() in a finally block: sem.acquire(); try { ... } finally { sem.release(); }\n" +
+"    - Verify the initial permit count matches the actual resource capacity");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/SharedCollectionDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/SharedCollectionDetector.java
@@ -200,7 +200,13 @@ public class SharedCollectionDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: use ConcurrentHashMap, CopyOnWriteArrayList, or synchronizedList/Map/Set");
+            sb.append("  Why: ArrayList, HashMap, and similar collections are explicitly not thread-safe. Concurrent writes corrupt\n" +
+                       "       internal array pointers and size counters, causing ArrayIndexOutOfBoundsException, infinite loops inside\n" +
+                       "       HashMap.get(), or silently lost entries — bugs that appear non-deterministically and are hard to reproduce.\n" +
+                       "  Fix:\n" +
+                       "    - Drop-in concurrent replacements: ConcurrentHashMap, ConcurrentLinkedQueue, CopyOnWriteArrayList\n" +
+                       "    - Wrapper (coarse-grained): Collections.synchronizedList/Map/Set — remember to lock the collection during iteration\n" +
+                       "    - Thread-confined: only access the collection from one thread; pass results between threads via a queue");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/SharedDecimalFormatDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/SharedDecimalFormatDetector.java
@@ -73,8 +73,13 @@ public class SharedDecimalFormatDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("SHARED DECIMAL FORMAT / NUMBER FORMAT DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
-            sb.append("  Fix: use ThreadLocal<DecimalFormat>, create a new instance per call, "
-                    + "or use String.format() / java.text.MessageFormat for simple cases");
+            sb.append("  Why: DecimalFormat and NumberFormat maintain mutable internal state during format/parse operations.\n" +
+                       "       Concurrent use corrupts that state, producing garbled output, NumberFormatException, or\n" +
+                       "       silently wrong numeric strings — bugs that vary by thread scheduling.\n" +
+                       "  Fix:\n" +
+                       "    - Thread-local: ThreadLocal<DecimalFormat> fmt = ThreadLocal.withInitial(() -> new DecimalFormat(\"#,##0.00\"));\n" +
+                       "    - Per-call: create a new DecimalFormat inside the method (cheap for infrequent use)\n" +
+                       "    - Simple cases: String.format(\"%.2f\", value) — delegates to thread-safe internals");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/SharedFormatterDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/SharedFormatterDetector.java
@@ -71,8 +71,12 @@ public class SharedFormatterDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("SHARED FORMATTER / PRINT-STREAM DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
-            sb.append("  Fix: use a thread-local Formatter, synchronize externally, "
-                    + "or replace with a thread-safe logging framework (SLF4J, java.util.logging)");
+            sb.append("  Why: java.util.Formatter and PrintStream maintain mutable internal buffers. Concurrent writes\n" +
+                       "       interleave output, producing garbled lines that mix characters from multiple threads.\n" +
+                       "  Fix:\n" +
+                       "    - Use a thread-safe logging framework (SLF4J, java.util.logging) which handles concurrent writes\n" +
+                       "    - Use a thread-local Formatter: ThreadLocal.withInitial(() -> new Formatter())\n" +
+                       "    - Synchronize externally on the shared formatter/stream for short, infrequent writes");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/SharedMatcherDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/SharedMatcherDetector.java
@@ -73,8 +73,13 @@ public class SharedMatcherDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("SHARED REGEX MATCHER DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
-            sb.append("  Fix: call pattern.matcher(input) inside each thread rather than "
-                    + "sharing a single Matcher instance; Pattern.compile() results are safe to share");
+            sb.append("  Why: A Matcher holds the current match position and region as mutable internal state.\n" +
+                       "       Concurrent find()/group() calls on the same Matcher corrupt that state, producing wrong\n" +
+                       "       match results, missed matches, or ArrayIndexOutOfBoundsException inside the regex engine.\n" +
+                       "  Fix:\n" +
+                       "    - Call pattern.matcher(input) inside each thread to obtain a fresh, independent Matcher\n" +
+                       "    - Pattern.compile() is safe to share — it is immutable after construction\n" +
+                       "    - For Java 11+: Pattern.asMatchPredicate() or Pattern.asPredicate() also thread-safe");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/SharedMessageDigestDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/SharedMessageDigestDetector.java
@@ -75,9 +75,13 @@ public class SharedMessageDigestDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("SHARED MESSAGE DIGEST DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
-            sb.append("  Fix: obtain a new MessageDigest.getInstance(...) per thread or "
-                    + "use ThreadLocal<MessageDigest>; alternatively use MessageDigest.clone() "
-                    + "to snapshot a configured instance per call");
+            sb.append("  Why: MessageDigest accumulates bytes in an internal buffer as you call update(). Concurrent calls\n" +
+                       "       mix bytes from different threads into the same digest, producing a hash of interleaved data\n" +
+                       "       rather than the intended input — a silent data-integrity failure.\n" +
+                       "  Fix:\n" +
+                       "    - Create a new MessageDigest.getInstance(\"SHA-256\") per call or per thread (cheap, non-blocking)\n" +
+                       "    - Or use ThreadLocal<MessageDigest> and call reset() at the start of each use\n" +
+                       "    - MessageDigest.clone() works if a pre-configured instance must be reused (requires the algorithm to support cloning)");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/SharedRandomDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/SharedRandomDetector.java
@@ -203,7 +203,13 @@ public class SharedRandomDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: use ThreadLocalRandom.current() for concurrent random number generation");
+            sb.append("  Why: java.util.Random uses a shared AtomicLong seed. Under concurrent use, threads contend on that\n" +
+                       "       single seed via CAS, causing high contention and throughput that degrades with thread count.\n" +
+                       "       In the worst case, the contention serialises random number generation across all threads.\n" +
+                       "  Fix:\n" +
+                       "    - Use ThreadLocalRandom.current().nextInt(...) — each thread has its own seed, zero contention\n" +
+                       "    - For cryptographic randomness: use SecureRandom with a per-thread or synchronized instance\n" +
+                       "    - For reproducible testing: SplittableRandom is thread-safe-by-split and supports parallel streams");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/SharedTimeZoneDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/SharedTimeZoneDetector.java
@@ -76,9 +76,11 @@ public class SharedTimeZoneDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("SHARED TIMEZONE MUTATION DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
-            sb.append("  Fix: treat TimeZone instances as immutable after construction — "
-                    + "use ZoneId (java.time) which is immutable and thread-safe, or obtain "
-                    + "a fresh TimeZone.getTimeZone(id) copy per thread if mutation is required");
+            sb.append("  Why: java.util.TimeZone is mutable. A call to setID() or setRawOffset() on a shared TimeZone instance\n" +
+                       "       changes the global timezone state, affecting every thread that uses that instance — including date\n" +
+                       "       formatting in unrelated parts of the application, producing silently wrong times.\n" +
+                       "  Fix: Use java.time.ZoneId (immutable) instead of java.util.TimeZone. If TimeZone is unavoidable,\n" +
+                       "       never mutate a shared instance — call TimeZone.getTimeZone(id) to get a fresh copy and treat it as read-only.");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/SharedXmlParserDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/SharedXmlParserDetector.java
@@ -84,9 +84,12 @@ public class SharedXmlParserDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("SHARED XML PARSER DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
-            sb.append("  Fix: obtain a new parser instance per thread (factories are "
-                    + "thread-safe for newXxx() calls), or pool parser instances with a "
-                    + "ThreadLocal<DocumentBuilder> / ThreadLocal<Transformer>");
+            sb.append("  Why: XML parsers (DocumentBuilder, SAXParser, Transformer) maintain mutable internal state during\n" +
+                       "       parsing. Concurrent use corrupts that state, producing wrong parse results, missed elements, or\n" +
+                       "       parser exceptions that vary by thread scheduling.\n" +
+                       "  Fix: Create a new parser instance per call — DocumentBuilderFactory.newDocumentBuilder() is the correct pattern:\n" +
+                       "       DocumentBuilder db = factory.newDocumentBuilder(); // factory is thread-safe; builder is not\n" +
+                       "       Or use ThreadLocal<DocumentBuilder> to amortise construction cost across repeated calls.");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/StampedLockDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/StampedLockDetector.java
@@ -125,8 +125,13 @@ public class StampedLockDetector {
                     sb.append("    - ").append(lockInfo).append("\n");
                 }
                 sb.append("  Problem: Optimistic read stamp used without calling validate()\n");
-                sb.append("  Fix: Always validate optimistic reads:\n");
-                sb.append("    if (lock.validate(stamp)) { /* use data */ }\n");
+                sb.append("  Why: An optimistic read acquires no lock. A concurrent writer may update the fields between the read\n" +
+                        "       and the validate() call, meaning the read values are a torn snapshot from two different states.\n" +
+                        "       Using data from a failed validation produces silently wrong results.\n");
+                sb.append("  Fix: Always call lock.validate(stamp) before using optimistically-read data:\n");
+                sb.append("    long stamp = lock.tryOptimisticRead();\n");
+                sb.append("    int x = field;  // read — may be torn\n");
+                sb.append("    if (!lock.validate(stamp)) { stamp = lock.readLock(); try { x = field; } finally { lock.unlockRead(stamp); } }\n");
             }
 
             if (!stampNotReleased.isEmpty()) {
@@ -134,8 +139,11 @@ public class StampedLockDetector {
                 for (String lockInfo : stampNotReleased) {
                     sb.append("    - ").append(lockInfo).append("\n");
                 }
-                sb.append("  Fix: Always unlock in finally block:\n");
-                sb.append("    try { lock.unlockRead(stamp); } finally { }\n");
+                sb.append("  Why: An unreleased StampedLock read or write lock blocks all subsequent writers (or all readers\n" +
+                        "       for a leaked write lock) indefinitely, causing the application to hang.\n");
+                sb.append("  Fix: Always release stamps in a finally block:\n");
+                sb.append("    long stamp = lock.readLock();\n");
+                sb.append("    try { /* read fields */ } finally { lock.unlockRead(stamp); }\n");
             }
 
             if (!hasIssues()) {

--- a/src/main/java/se/deversity/asynctest/diagnostics/StatefulLambdaDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/StatefulLambdaDetector.java
@@ -100,8 +100,14 @@ public class StatefulLambdaDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("STATEFUL LAMBDA SHARED ACROSS THREADS DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
-            sb.append("  Fix: use AtomicInteger/LongAdder for captured counters, "
-                    + "or create a new lambda instance per task to avoid shared mutable captures");
+            sb.append("  Why: A lambda that captures a mutable variable or field shares that state with every thread that\n"
+                    + "       executes the lambda concurrently. Without synchronization, two threads can read the same value,\n"
+                    + "       both modify it, and one update is silently lost — a classic lost-update race condition inside\n"
+                    + "       what looks like a simple closure.\n"
+                    + "  Fix:\n"
+                    + "    - Use AtomicInteger/AtomicLong/LongAdder for captured numeric counters (lock-free, correct)\n"
+                    + "    - Capture only effectively-final, immutable values and pass mutable state via method parameters\n"
+                    + "    - Create a new lambda (or a new capturing context) per task so each thread gets its own state");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/StreamClosingDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/StreamClosingDetector.java
@@ -228,7 +228,13 @@ public class StreamClosingDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: use try-with-resources to ensure streams are always closed");
+            sb.append("  Why: An unclosed Stream that wraps I/O resources (Files.lines(), Files.walk()) holds an open file descriptor.\n" +
+                       "       Leaving it open leaks the descriptor for the lifetime of the process. Under load, leaked descriptors\n" +
+                       "       exhaust the OS file descriptor limit, causing 'Too many open files' on subsequent opens.\n" +
+                       "  Fix: Always close streams that wrap I/O: use try-with-resources:\n" +
+                       "       try (Stream<String> lines = Files.lines(path)) { ... }\n" +
+                       "       or call stream.close() in a finally block.\n" +
+                       "       Streams returned by collection methods (list.stream()) do not hold resources and do not need closing.");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/StringBuilderDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/StringBuilderDetector.java
@@ -244,7 +244,13 @@ public class StringBuilderDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Fix: use ThreadLocal<StringBuilder> or build strings locally per-thread and join at the end");
+            sb.append("  Why: StringBuilder is explicitly not thread-safe. The internal char[] and count field are updated\n"
+                    + "       without synchronization. Concurrent append() calls corrupt the buffer, producing garbled output,\n"
+                    + "       StringIndexOutOfBoundsException, or silently lost characters — bugs that vary by thread scheduling.\n"
+                    + "  Fix:\n"
+                    + "    - Build strings locally per thread and combine the results afterwards (collect into a list, then join)\n"
+                    + "    - Use ThreadLocal<StringBuilder> if you must reuse a buffer per thread (call sb.setLength(0) to reset)\n"
+                    + "    - Use StringBuffer instead if sharing across threads is unavoidable (synchronized, but slower)");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/SystemPropertyMutationDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/SystemPropertyMutationDetector.java
@@ -121,8 +121,14 @@ public class SystemPropertyMutationDetector {
                 sb.append("  Warnings (single-thread mutations):\n");
                 for (String w : singleThreadMutations) sb.append("    - ").append(w).append("\n");
             }
-            sb.append("  Fix: restore modified properties in an @AfterEach block, or use "
-                    + "a dedicated test configuration mechanism instead of System.setProperty");
+            sb.append("  Why: System.setProperty() modifies a global JVM-wide map. Concurrent mutations from multiple threads\n" +
+                       "       race without synchronization. More critically, tests that mutate system properties and do not\n" +
+                       "       restore them contaminate every subsequent test in the same JVM — a notoriously hard-to-diagnose\n" +
+                       "       source of flaky tests.\n" +
+                       "  Fix: Use try/finally to always restore the original value:\n" +
+                       "       String old = System.getProperty(key); try { System.setProperty(key, value); doWork(); }\n" +
+                       "       finally { if (old == null) System.clearProperty(key); else System.setProperty(key, old); }\n" +
+                       "       For test isolation, prefer mocking the consumer of the property rather than mutating the global state.");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/ThreadFactoryDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ThreadFactoryDetector.java
@@ -100,9 +100,11 @@ public class ThreadFactoryDetector {
                 for (String threadInfo : missingExceptionHandler) {
                     sb.append("    - ").append(threadInfo).append("\n");
                 }
-                sb.append("  Problem: Uncaught exceptions will be silently swallowed\n");
-                sb.append("  Fix: Set uncaught exception handler:\n");
-                sb.append("    thread.setUncaughtExceptionHandler((t, e) -> e.printStackTrace());\n");
+                sb.append("  Why: An uncaught exception in a thread kills that thread silently. Without a handler, the failure\n");
+                sb.append("       is never logged, the work is never retried, and the thread pool shrinks without anyone noticing.\n");
+                sb.append("  Fix: Set an uncaught exception handler on every created thread:\n");
+                sb.append("    thread.setUncaughtExceptionHandler((t, e) -> log.error(\"Thread {} died\", t.getName(), e));\n");
+                sb.append("  Or set a JVM-wide default: Thread.setDefaultUncaughtExceptionHandler(...)\n");
             }
 
             if (!nonDaemonThreads.isEmpty()) {
@@ -110,8 +112,10 @@ public class ThreadFactoryDetector {
                 for (String threadInfo : nonDaemonThreads) {
                     sb.append("    - ").append(threadInfo).append("\n");
                 }
-                sb.append("  Warning: Non-daemon threads prevent JVM shutdown\n");
-                sb.append("  Fix: Set thread as daemon: thread.setDaemon(true);\n");
+                sb.append("  Why: The JVM waits for all non-daemon threads to finish before exiting. A leaked non-daemon thread\n");
+                sb.append("       prevents clean shutdown and may keep processes alive in production or cause test hangs.\n");
+                sb.append("  Fix: Mark background threads as daemons so the JVM does not wait for them:\n");
+                sb.append("    thread.setDaemon(true);  // must be called before thread.start()\n");
             }
 
             if (!unnamedThreads.isEmpty()) {
@@ -119,9 +123,10 @@ public class ThreadFactoryDetector {
                 for (String threadInfo : unnamedThreads) {
                     sb.append("    - ").append(threadInfo).append("\n");
                 }
-                sb.append("  Warning: Hard to debug without meaningful names\n");
-                sb.append("  Fix: Use descriptive thread names:\n");
-                sb.append("    new Thread(runnable, \"pool-1-worker-\" + threadNumber);\n");
+                sb.append("  Why: Thread names appear in stack traces, thread dumps, and monitoring dashboards. Generic names like\n");
+                sb.append("       \"Thread-42\" make it impossible to identify which component a blocked or crashing thread belongs to.\n");
+                sb.append("  Fix: Assign descriptive names in the factory:\n");
+                sb.append("    thread.setName(\"payment-worker-\" + threadCount.incrementAndGet());\n");
             }
 
             if (!hasIssues()) {

--- a/src/main/java/se/deversity/asynctest/diagnostics/ThreadLeakDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ThreadLeakDetector.java
@@ -249,7 +249,13 @@ public class ThreadLeakDetector {
                             sb.append("        at ").append(leak.creationStack[j]).append("\n");
                         }
                     }
-                    sb.append("      Fix: Ensure thread is properly terminated with join() or executor.shutdown()\n");
+                    sb.append("      Why: Threads that outlive the test consume OS resources (stack memory, file descriptors) and may\n");
+                    sb.append("           interfere with subsequent tests by writing to shared state, holding locks, or preventing JVM exit.\n");
+                    sb.append("      Fix:\n");
+                    sb.append("        - Daemon threads: set thread.setDaemon(true) so the JVM terminates them automatically on exit\n");
+                    sb.append("        - Managed threads: call thread.join() or executor.shutdown() + awaitTermination() in a finally block\n");
+                    sb.append("        - Use try-with-resources if the executor implements AutoCloseable (Java 19+ ExecutorService)\n");
+                    sb.append("        - Pass a stop signal via a volatile boolean or interrupt: thread.interrupt() + check Thread.interrupted()\n");
                 }
             }
             return sb.toString();

--- a/src/main/java/se/deversity/asynctest/diagnostics/ThreadLocalContaminationDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ThreadLocalContaminationDetector.java
@@ -90,8 +90,13 @@ public class ThreadLocalContaminationDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("THREADLOCAL CONTAMINATION DETECTED:\n");
             for (String c : contaminations) sb.append("  - ").append(c).append("\n");
-            sb.append("  Fix: call ThreadLocal.remove() in a task-finally block, "
-                    + "or use a try-with-resources wrapper that clears the value on close");
+            sb.append("  Why: Thread pools reuse threads across tasks. A ThreadLocal set by Task A persists into Task B\n" +
+                    "       if it is not explicitly cleared. Task B then reads stale, unintended context — a security\n" +
+                    "       boundary violation if the value is a user identity or tenant, and a correctness bug otherwise.\n" +
+                    "  Fix:\n" +
+                    "    - Call ThreadLocal.remove() in a task-finally block: try { doWork(); } finally { ctx.remove(); }\n" +
+                    "    - Or wrap in AutoCloseable: try (var ctx = ScopedContext.bind(value)) { doWork(); }\n" +
+                    "    - Consider ScopedValue (Java 21+) instead — it is automatically scoped to the current call and cleaned up");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/ThreadPoolDeadlockDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ThreadPoolDeadlockDetector.java
@@ -277,7 +277,7 @@ public class ThreadPoolDeadlockDetector {
             sb.append(IssueSeverity.HIGH.format())
               .append(": ")
               .append(risks.size())
-              .append(" pool(s) with potential deadlock scenarios\n");
+              .append(" pool(s) with potential deadlock scenarios — tasks that submit more work to the same bounded executor and then wait for it will deadlock when all pool threads are occupied and the queue is full\n");
 
             for (int i = 0; i < risks.size(); i++) {
                 PoolDeadlockRisk risk = risks.get(i);

--- a/src/main/java/se/deversity/asynctest/diagnostics/ThreadStarvationDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ThreadStarvationDetector.java
@@ -314,8 +314,14 @@ public class ThreadStarvationDetector {
                     sb.append("  [").append(i + 1).append("] ").append(event.executorName).append("\n");
                     sb.append("      Wait time: ").append(event.waitTimeMs).append("ms\n");
                     sb.append("      Thread: ").append(event.threadName).append("\n");
-                    sb.append("      Problem: Task waited excessively before execution\n");
-                    sb.append("      Fix: Increase pool size, reduce task execution time, or use work-stealing\n");
+                    sb.append("      Why: The thread pool is saturated — tasks queue faster than workers finish them.\n");
+                    sb.append("           Persistent starvation means time-sensitive tasks (health-checks, user requests, timeouts)\n");
+                    sb.append("           can be delayed indefinitely, causing cascading failures across dependent services.\n");
+                    sb.append("      Fix:\n");
+                    sb.append("        - Increase pool size: Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 2)\n");
+                    sb.append("        - Reduce per-task duration: move I/O-bound work to a dedicated I/O pool; use async I/O\n");
+                    sb.append("        - Use a work-stealing pool: Executors.newWorkStealingPool() balances load across idle threads\n");
+                    sb.append("        - Apply backpressure: reject or throttle submissions when the queue exceeds a threshold\n");
                 }
                 if (events.size() > 10) {
                     sb.append("  ... and ").append(events.size() - 10).append(" more events\n");

--- a/src/main/java/se/deversity/asynctest/diagnostics/TimerDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/TimerDetector.java
@@ -227,6 +227,8 @@ public class TimerDetector {
             sb.append("TIMER ISSUES DETECTED:\n");
 
             if (!timerThreadFailures.isEmpty()) {
+                sb.append("  Why: An uncaught exception in a TimerTask cancels ALL future tasks on that Timer silently.\n" +
+                           "       The timer continues to exist but never fires another task.\n");
                 sb.append("  Timer Thread Failures (tasks silently cancelled):\n");
                 for (String issue : timerThreadFailures) {
                     sb.append("    - ").append(issue).append("\n");
@@ -258,7 +260,10 @@ public class TimerDetector {
                 sb.append("  No critical issues detected.\n");
             }
 
-            sb.append("  Fix: replace java.util.Timer with ScheduledExecutorService");
+            sb.append("  Why: A Timer that is never cancelled keeps its TimerThread alive forever, preventing JVM exit\n" +
+                       "       and consuming an OS thread. Scheduled tasks continue firing even after the test ends,\n" +
+                       "       interfering with subsequent tests.\n" +
+                       "  Fix: replace java.util.Timer with ScheduledExecutorService");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/UnboundedQueueDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/UnboundedQueueDetector.java
@@ -281,6 +281,13 @@ public class UnboundedQueueDetector {
                         }
                     }
                 }
+                sb.append("\nWhy: Queues without a capacity bound grow without limit under sustained load, eventually exhausting heap\n" +
+                          "     memory (OutOfMemoryError), hiding producer/consumer imbalances, and masking backpressure that should\n" +
+                          "     signal the producer to slow down.\n" +
+                          "Fix:\n" +
+                          "  - Use a bounded queue: new ArrayBlockingQueue<>(capacity) or new LinkedBlockingQueue<>(capacity)\n" +
+                          "  - Choose capacity deliberately: too small starves the consumer; too large hides backpressure\n" +
+                          "  - On a full queue, use offer(item, timeout, unit) and handle rejection explicitly (log, shed load, or block)");
             }
             return sb.toString();
         }

--- a/src/main/java/se/deversity/asynctest/diagnostics/UncaughtExceptionHandlerDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/UncaughtExceptionHandlerDetector.java
@@ -93,9 +93,13 @@ public class UncaughtExceptionHandlerDetector {
         public String toString() {
             StringBuilder sb = new StringBuilder("UNCAUGHT EXCEPTION HANDLER MISSING DETECTED:\n");
             for (String v : violations) sb.append("  - ").append(v).append("\n");
-            sb.append("  Fix: call thread.setUncaughtExceptionHandler(handler) before "
-                    + "thread.start(), or use a ThreadFactory that installs a handler "
-                    + "on every thread created by the pool");
+            sb.append("  Why: An uncaught exception kills the thread silently. Without an uncaught exception handler, the failure\n" +
+                       "       is never logged, the task is never retried, and the thread pool shrinks by one — often leading to\n" +
+                       "       gradual starvation as more threads die without anyone noticing.\n" +
+                       "  Fix: Set a handler on every thread or set a JVM-wide default:\n" +
+                       "       thread.setUncaughtExceptionHandler((t, e) -> log.error(\"Thread {} died\", t.getName(), e));\n" +
+                       "       // or globally:\n" +
+                       "       Thread.setDefaultUncaughtExceptionHandler((t, e) -> log.error(\"Unhandled exception\", e));");
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/VirtualThreadPinningDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/VirtualThreadPinningDetector.java
@@ -271,7 +271,7 @@ public class VirtualThreadPinningDetector {
             sb.append(IssueSeverity.MEDIUM.format())
               .append(": ")
               .append(events.size())
-              .append(" pinning event(s) detected (max concurrent: ")
+              .append(" virtual thread pinning event(s) detected — a pinned virtual thread cannot unmount from its carrier platform thread, so that carrier is unavailable to other virtual threads for the entire duration of the block (max concurrent pinned: ")
               .append(maxPinnedCount)
               .append(")\n");
 

--- a/src/main/java/se/deversity/asynctest/diagnostics/VolatileArrayDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/VolatileArrayDetector.java
@@ -119,6 +119,9 @@ public class VolatileArrayDetector {
                     sb.append("               not individual elements. Element updates may not\n");
                     sb.append("               be visible across threads.\n");
                 }
+                sb.append("  Why: The volatile keyword guarantees visibility of the array reference (the pointer to the array object),\n");
+                sb.append("       NOT the individual array elements. A write to array[i] in Thread A may remain invisible to Thread B\n");
+                sb.append("       indefinitely — producing stale reads, lost updates, and non-deterministic results.\n");
                 sb.append("  Fix: Use one of these alternatives:\n");
                 sb.append("    - AtomicReferenceArray<T>\n");
                 sb.append("    - AtomicIntegerArray / AtomicLongArray\n");

--- a/src/main/java/se/deversity/asynctest/diagnostics/WaitTimeoutDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/WaitTimeoutDetector.java
@@ -114,10 +114,13 @@ public class WaitTimeoutDetector {
                         sb.append("      WARNING: No notify/notifyAll detected - potential deadlock!\n");
                     }
                 }
-                sb.append("  Fix: Use wait(timeout) instead of wait():\n");
-                sb.append("    lock.wait(5000);  // 5 second timeout\n");
-                sb.append("    // Handle timeout case\n");
-                sb.append("  Or ensure proper notify/notifyAll is called.\n");
+                sb.append("  Why: Calling wait() without a timeout means the thread can only wake up via notify()/notifyAll().\n");
+                sb.append("       If the notification is never sent (due to a bug) or fires before wait() is called (a missed signal),\n");
+                sb.append("       the thread hangs indefinitely — freezing the test or the application.\n");
+                sb.append("  Fix: always supply a timeout so the thread can detect stalls and bail out:\n");
+                sb.append("    lock.wait(5000);  // 5 second timeout — check the condition again after waking\n");
+                sb.append("    // Handle timeout: log warning, retry, or fail fast\n");
+                sb.append("  Or ensure a matching notifyAll() is always called when the condition becomes true.\n");
             }
 
             if (!hasIssues()) {

--- a/src/main/java/se/deversity/asynctest/diagnostics/WakeupDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/WakeupDetector.java
@@ -172,7 +172,10 @@ public class WakeupDetector {
                 for (String issue : monitorsWithSpuriousWakeups) {
                     sb.append("  - ").append(issue).append("\n");
                 }
-                sb.append("  Fix: Wrap wait() in while loop checking condition\n");
+                sb.append("  Why: wait() can return spuriously (without a notification) due to OS-level interrupts or JVM internals.\n" +
+                           "       Proceeding on a single if-check instead of a while loop causes the thread to act as if the\n" +
+                           "       condition is met when it is not, producing logic errors or data corruption.\n" +
+                           "  Fix: Always wrap wait() in a while loop: synchronized(lock) { while (!condition) { lock.wait(); } }\n");
             }
             
             if (!monitorsWithLostNotifications.isEmpty()) {
@@ -180,7 +183,11 @@ public class WakeupDetector {
                 for (String issue : monitorsWithLostNotifications) {
                     sb.append("  - ").append(issue).append("\n");
                 }
-                sb.append("  Fix: Ensure notify() comes after another thread calls wait()\n");
+                sb.append("  Why: A notify() fired before any thread calls wait() is silently lost — the waiting thread will\n" +
+                           "       never receive it and blocks forever. This is the classic \"lost wakeup\" race.\n" +
+                           "  Fix: Set a boolean flag before calling notify(), and check it in a while loop before wait():\n" +
+                           "       ready = true; lock.notifyAll();  // sender\n" +
+                           "       while (!ready) { lock.wait(); } // receiver — handles notify arriving before wait()\n");
             }
             
             if (!alwaysNotifyWithoutWait.isEmpty()) {
@@ -188,7 +195,12 @@ public class WakeupDetector {
                 for (String monitor : alwaysNotifyWithoutWait) {
                     sb.append("  - ").append(monitor).append("\n");
                 }
-                sb.append("  Fix: Implement proper wait/notify coordination\n");
+                sb.append("  Why: Calling notify() without a corresponding wait() is a no-op that wastes a signal.\n" +
+                           "       It usually indicates that the notify is being fired unconditionally rather than in response\n" +
+                           "       to a state change, breaking the protocol between producer and consumer.\n" +
+                           "  Fix: Pair notify() with a state change and pair wait() with a condition check:\n" +
+                           "       // Producer: condition = true; synchronized(lock) { lock.notifyAll(); }\n" +
+                           "       // Consumer: synchronized(lock) { while (!condition) { lock.wait(); } }\n");
             }
             
             return sb.toString();

--- a/src/main/java/se/deversity/asynctest/diagnostics/WeakReferenceRaceDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/WeakReferenceRaceDetector.java
@@ -122,8 +122,12 @@ public class WeakReferenceRaceDetector {
             StringBuilder sb = new StringBuilder("WEAK REFERENCE RACE DETECTED:\n");
             for (String v : violations) sb.append("  ERROR - ").append(v).append("\n");
             for (String w : warnings)   sb.append("  WARN  - ").append(w).append("\n");
-            sb.append("  Fix: always null-check WeakReference.get() immediately before use; "
-                    + "consider storing the result in a local variable and re-checking after every potential GC point");
+            sb.append("  Why: The garbage collector may collect a weakly-reachable object at any moment, including between\n"
+                    + "       a null-check and the next use of the result. Without a null-check on every get() call,\n"
+                    + "       code will throw NullPointerException non-deterministically under GC pressure.\n"
+                    + "  Fix: assign get() to a local variable once and null-check that variable:\n"
+                    + "       T ref = weakRef.get(); if (ref != null) { use(ref); }  // safe: local variable not GC'd\n"
+                    + "       Never call weakRef.get() twice expecting the same result — the GC can collect between the two calls");
             return sb.toString();
         }
     }


### PR DESCRIPTION
Every detector (66 files) now produces a three-part message when it fires:
- What: the specific violation with field names, thread IDs, counts, etc.
- Why: concise explanation of the consequence (data corruption, hang, crash, etc.)
- Fix: concrete, actionable steps or code examples

Previously many detectors had only the What and Fix; LivelockDetector had no Fix at all. The Why section is now consistently present, making it clear to the developer reading the failure why the pattern is dangerous and what it can cause in production.