### PR TITLE
chore: release 1.3.0

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -10,7 +10,7 @@ on:
       asyncTestVersion:
         description: "Library version to test against (default: current build)"
         required: false
-        default: "0.10.0"
+        default: "1.3.0"
 
 permissions:
   contents: read
@@ -57,7 +57,7 @@ jobs:
       - name: Run load tests (fast subset — capped for CI)
         run: |
           ./gradlew -p load-tests test \
-            -PasyncTestVersion=${{ inputs.asyncTestVersion || '0.10.0' }} \
+            -PasyncTestVersion=${{ inputs.asyncTestVersion || '1.3.0' }} \
             -PloadTestFast=true
 
       - name: Upload throughput results

--- a/consumer-fixture/build.gradle.kts
+++ b/consumer-fixture/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "se.deversity.async-test-lib"
-version = "0.10.0"
+version = "1.3.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -18,7 +18,7 @@ repositories {
     mavenCentral()
 }
 
-val asyncTestVersion = "0.10.0"
+val asyncTestVersion = "1.3.0"
 val junitVersion = "6.0.3"
 
 dependencies {

--- a/consumer-fixture/pom.xml
+++ b/consumer-fixture/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.async-test-lib</groupId>
     <artifactId>consumer-fixture</artifactId>
-    <version>0.10.0</version>
+    <version>1.3.0</version>
     <packaging>jar</packaging>
 
     <name>Async Test Consumer Fixture</name>
@@ -16,7 +16,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <async-test.version>0.10.0</async-test.version>
+        <async-test.version>1.3.0</async-test.version>
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/examples/01-completablefuture-exception-handling/build.gradle.kts
+++ b/examples/01-completablefuture-exception-handling/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
     mavenLocal()
 }
 
-val asyncTestVersion = "0.10.0"
+val asyncTestVersion = "1.3.0"
 val junitVersion = "5.10.2"
 // The library brings in junit-jupiter-engine:6.0.3 as an api dependency, which wins
 // over junitVersion above. Pin the launcher to match so Gradle's bundled 5.x launcher

--- a/examples/01-completablefuture-exception-handling/pom.xml
+++ b/examples/01-completablefuture-exception-handling/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
 
     <dependencies>

--- a/examples/02-visibility-volatile-flag/build.gradle.kts
+++ b/examples/02-visibility-volatile-flag/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
     mavenLocal()
 }
 
-val asyncTestVersion = "0.10.0"
+val asyncTestVersion = "1.3.0"
 val junitVersion = "5.10.2"
 // The library brings in junit-jupiter-engine:6.0.3 as an api dependency, which wins
 // over junitVersion above. Pin the launcher to match so Gradle's bundled 5.x launcher

--- a/examples/02-visibility-volatile-flag/pom.xml
+++ b/examples/02-visibility-volatile-flag/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
 
     <dependencies>

--- a/examples/03-shared-collection/pom.xml
+++ b/examples/03-shared-collection/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
 
     <dependencies>

--- a/examples/04-virtual-thread-context-leak/build.gradle.kts
+++ b/examples/04-virtual-thread-context-leak/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
     mavenLocal()
 }
 
-val asyncTestVersion = "0.10.0"
+val asyncTestVersion = "1.3.0"
 val junitVersion = "5.10.2"
 val junitPlatformVersion = "6.0.3"
 

--- a/examples/05-lock-contention/pom.xml
+++ b/examples/05-lock-contention/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
 
     <dependencies>

--- a/examples/09-uncommitted-changes-detection/build.gradle.kts
+++ b/examples/09-uncommitted-changes-detection/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
     mavenCentral()
 }
 
-val asyncTestVersion = "0.10.0"
+val asyncTestVersion = "1.3.0"
 val junitPlatformVersion = "6.0.3"
 
 dependencies {

--- a/examples/09-uncommitted-changes-detection/pom.xml
+++ b/examples/09-uncommitted-changes-detection/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
 
     <dependencies>

--- a/examples/10-shared-non-thread-safe-types/pom.xml
+++ b/examples/10-shared-non-thread-safe-types/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
 
     <dependencies>

--- a/examples/11-interrupt-swallowing/pom.xml
+++ b/examples/11-interrupt-swallowing/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
 
     <dependencies>

--- a/examples/12-mdc-context-leak/pom.xml
+++ b/examples/12-mdc-context-leak/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency>

--- a/examples/13-system-property-mutation/pom.xml
+++ b/examples/13-system-property-mutation/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency>

--- a/examples/14-future-ignored/pom.xml
+++ b/examples/14-future-ignored/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency>

--- a/examples/15-explicit-gc/pom.xml
+++ b/examples/15-explicit-gc/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency><groupId>se.deversity.async-test-lib</groupId><artifactId>async-test-lib</artifactId><version>${async-test-lib.version}</version><scope>test</scope></dependency>

--- a/examples/16-deprecated-thread-api/pom.xml
+++ b/examples/16-deprecated-thread-api/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency><groupId>se.deversity.async-test-lib</groupId><artifactId>async-test-lib</artifactId><version>${async-test-lib.version}</version><scope>test</scope></dependency>

--- a/examples/17-shared-xml-parser/pom.xml
+++ b/examples/17-shared-xml-parser/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency><groupId>se.deversity.async-test-lib</groupId><artifactId>async-test-lib</artifactId><version>${async-test-lib.version}</version><scope>test</scope></dependency>

--- a/examples/18-boxed-primitive-lock/pom.xml
+++ b/examples/18-boxed-primitive-lock/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency><groupId>se.deversity.async-test-lib</groupId><artifactId>async-test-lib</artifactId><version>${async-test-lib.version}</version><scope>test</scope></dependency>

--- a/examples/19-shared-timezone/pom.xml
+++ b/examples/19-shared-timezone/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency><groupId>se.deversity.async-test-lib</groupId><artifactId>async-test-lib</artifactId><version>${async-test-lib.version}</version><scope>test</scope></dependency>

--- a/examples/20-uncaught-exception-handler/pom.xml
+++ b/examples/20-uncaught-exception-handler/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
-        <async-test-lib.version>0.10.0</async-test-lib.version>
+        <async-test-lib.version>1.3.0</async-test-lib.version>
     </properties>
     <dependencies>
         <dependency><groupId>se.deversity.async-test-lib</groupId><artifactId>async-test-lib</artifactId><version>${async-test-lib.version}</version><scope>test</scope></dependency>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.10.0
+version=1.3.0
 group=se.deversity.async-test-lib

--- a/load-tests/build.gradle.kts
+++ b/load-tests/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
     mavenCentral()
 }
 
-val asyncTestVersion: String = project.findProperty("asyncTestVersion") as String? ?: "0.10.0"
+val asyncTestVersion: String = project.findProperty("asyncTestVersion") as String? ?: "1.3.0"
 val junitVersion = "6.0.3"
 
 // Publish library to local Maven before running load tests:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.async-test-lib</groupId>
     <artifactId>async-test-lib</artifactId>
-    <version>0.10.0</version>
+    <version>1.3.0</version>
     <packaging>jar</packaging>
 
     <name>Async Test Library</name>


### PR DESCRIPTION
Bump project version from 0.10.0 to 1.3.0 across pom.xml, gradle.properties, consumer-fixture, examples build files, load-tests default, and the load-tests workflow input. @since 0.10.0 Javadoc and prose mentions in CHANGELOG/USAGE/ example READMEs are intentionally left as historical records.