### PR TITLE
feat: CI/CD fail gates, structured JSON output, and IntelliJ plugin (v1.5.0)

### DIFF
--- a/src/main/java/se/deversity/asynctest/AsyncTestListenerRegistry.java
+++ b/src/main/java/se/deversity/asynctest/AsyncTestListenerRegistry.java
@@ -138,12 +138,7 @@ public final class AsyncTestListenerRegistry {
     }
 
     private static IssueSeverity parseSeverity(String report) {
-        if (report == null) return IssueSeverity.HIGH;
-        if (report.contains("CRITICAL") || report.contains("🔴")) return IssueSeverity.CRITICAL;
-        if (report.contains("HIGH")     || report.contains("🟠")) return IssueSeverity.HIGH;
-        if (report.contains("MEDIUM")   || report.contains("🟡")) return IssueSeverity.MEDIUM;
-        if (report.contains("LOW")      || report.contains("🟢")) return IssueSeverity.LOW;
-        return IssueSeverity.HIGH;
+        return IssueSeverity.fromReport(report);
     }
 
     /**

--- a/src/main/java/se/deversity/asynctest/diagnostics/IssueSeverity.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/IssueSeverity.java
@@ -89,4 +89,21 @@ public enum IssueSeverity {
     public String format() {
         return getAnsiColor() + label + getAnsiReset();
     }
+
+    /**
+     * Infers the severity from a detector report string by scanning for
+     * {@link IssueSeverity} emoji/keyword markers. Defaults to {@link #HIGH} when
+     * no marker is present, matching the assumption that untagged reports are significant.
+     *
+     * @param report the raw report text produced by a detector; {@code null} is treated as empty
+     * @return the matched severity, or {@link #HIGH} if none is found
+     */
+    public static IssueSeverity fromReport(String report) {
+        if (report == null || report.isEmpty()) return HIGH;
+        if (report.contains("CRITICAL") || report.contains("🔴")) return CRITICAL;
+        if (report.contains("HIGH")     || report.contains("🟠")) return HIGH;
+        if (report.contains("MEDIUM")   || report.contains("🟡")) return MEDIUM;
+        if (report.contains("LOW")      || report.contains("🟢")) return LOW;
+        return HIGH;
+    }
 }

--- a/src/main/java/se/deversity/asynctest/report/DetectorFinding.java
+++ b/src/main/java/se/deversity/asynctest/report/DetectorFinding.java
@@ -1,30 +1,21 @@
 package se.deversity.asynctest.report;
 
+import se.deversity.asynctest.diagnostics.IssueSeverity;
+
 /**
  * Immutable snapshot of a single detector finding produced during a test run.
- *
- * <p>Severity is inferred from the report text using the {@link se.deversity.asynctest.diagnostics.IssueSeverity}
- * emoji/keyword markers. Reports that contain no severity marker default to {@code "HIGH"}.
  */
 public final class DetectorFinding {
 
     public final String detectorName;
-    public final String severity;
+    public final IssueSeverity severity;
     public final String report;
     public final long timestampMs;
 
-    public DetectorFinding(String detectorName, String report, long timestampMs) {
+    public DetectorFinding(String detectorName, IssueSeverity severity, String report, long timestampMs) {
         this.detectorName = detectorName;
+        this.severity = severity != null ? severity : IssueSeverity.HIGH;
         this.report = report != null ? report : "";
         this.timestampMs = timestampMs;
-        this.severity = parseSeverity(this.report);
-    }
-
-    private static String parseSeverity(String report) {
-        if (report.contains("CRITICAL") || report.contains("🔴")) return "CRITICAL";
-        if (report.contains("HIGH")     || report.contains("🟠")) return "HIGH";
-        if (report.contains("MEDIUM")   || report.contains("🟡")) return "MEDIUM";
-        if (report.contains("LOW")      || report.contains("🟢")) return "LOW";
-        return "HIGH";
     }
 }

--- a/src/main/java/se/deversity/asynctest/report/JUnitXmlReportListener.java
+++ b/src/main/java/se/deversity/asynctest/report/JUnitXmlReportListener.java
@@ -1,8 +1,8 @@
 package se.deversity.asynctest.report;
 
 import se.deversity.asynctest.AsyncTestListener;
+import se.deversity.asynctest.diagnostics.IssueSeverity;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -57,7 +57,7 @@ public final class JUnitXmlReportListener implements AsyncTestListener {
      * Registers a JVM shutdown hook to flush the report automatically.
      */
     public JUnitXmlReportListener() {
-        this(resolveDefaultOutputDir(), true);
+        this(ReportListeners.resolveDefaultOutputDir(), true);
     }
 
     /**
@@ -71,7 +71,7 @@ public final class JUnitXmlReportListener implements AsyncTestListener {
     }
 
     /**
-     * @param outputDir the directory to write the XML report into
+     * @param outputDir            the directory to write the XML report into
      * @param registerShutdownHook whether to register a JVM shutdown hook for auto-flush
      */
     public JUnitXmlReportListener(String outputDir, boolean registerShutdownHook) {
@@ -83,8 +83,8 @@ public final class JUnitXmlReportListener implements AsyncTestListener {
     }
 
     @Override
-    public void onDetectorReport(String detectorName, String report) {
-        findings.add(new DetectorFinding(detectorName, report, System.currentTimeMillis()));
+    public void onStructuredReport(String detectorName, IssueSeverity severity, String report) {
+        findings.add(new DetectorFinding(detectorName, severity, report, System.currentTimeMillis()));
     }
 
     /**
@@ -118,7 +118,7 @@ public final class JUnitXmlReportListener implements AsyncTestListener {
 
     private static void writeXml(Path xmlFile, List<DetectorFinding> snapshot) throws IOException {
         int count = snapshot.size();
-        StringBuilder sb = new StringBuilder(512);
+        StringBuilder sb = new StringBuilder(Math.max(1024, count * 300));
         sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
         sb.append("<testsuite name=\"AsyncTest Concurrency Detector Report\"")
           .append(" tests=\"").append(count).append("\"")
@@ -127,7 +127,7 @@ public final class JUnitXmlReportListener implements AsyncTestListener {
           .append(" timestamp=\"").append(Instant.now()).append("\">\n");
 
         for (DetectorFinding f : snapshot) {
-            String message = "[" + f.severity + "] " + xmlEscape(f.detectorName)
+            String message = "[" + f.severity.name() + "] " + xmlEscape(f.detectorName)
                            + " detected a concurrency issue";
             sb.append("  <testcase name=\"").append(xmlEscape(f.detectorName))
               .append("\" classname=\"se.deversity.asynctest.detectors\"")
@@ -148,11 +148,5 @@ public final class JUnitXmlReportListener implements AsyncTestListener {
                 .replace("<", "&lt;")
                 .replace(">", "&gt;")
                 .replace("\"", "&quot;");
-    }
-
-    private static String resolveDefaultOutputDir() {
-        if (new File("target").isDirectory()) return "target/async-test-reports";
-        if (new File("build").isDirectory())  return "build/async-test-reports";
-        return "async-test-reports";
     }
 }

--- a/src/main/java/se/deversity/asynctest/report/JsonReportListener.java
+++ b/src/main/java/se/deversity/asynctest/report/JsonReportListener.java
@@ -3,7 +3,6 @@ package se.deversity.asynctest.report;
 import se.deversity.asynctest.AsyncTestListener;
 import se.deversity.asynctest.diagnostics.IssueSeverity;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -56,7 +55,7 @@ public final class JsonReportListener implements AsyncTestListener {
     private static final String REPORT_FILENAME = "async-test-report.json";
     private static final String VERSION = "1.5.0";
 
-    private final List<StructuredFinding> findings = new CopyOnWriteArrayList<>();
+    private final List<DetectorFinding> findings = new CopyOnWriteArrayList<>();
     private final String outputDir;
     private final AtomicBoolean flushed = new AtomicBoolean(false);
 
@@ -65,7 +64,7 @@ public final class JsonReportListener implements AsyncTestListener {
      * Registers a JVM shutdown hook to flush the report automatically.
      */
     public JsonReportListener() {
-        this(resolveDefaultOutputDir(), true);
+        this(ReportListeners.resolveDefaultOutputDir(), true);
     }
 
     /**
@@ -92,8 +91,7 @@ public final class JsonReportListener implements AsyncTestListener {
 
     @Override
     public void onStructuredReport(String detectorName, IssueSeverity severity, String report) {
-        findings.add(new StructuredFinding(detectorName, severity.name(), report,
-            System.currentTimeMillis()));
+        findings.add(new DetectorFinding(detectorName, severity, report, System.currentTimeMillis()));
     }
 
     /**
@@ -125,23 +123,24 @@ public final class JsonReportListener implements AsyncTestListener {
         return findings.size();
     }
 
-    private static void writeJson(Path jsonFile, List<StructuredFinding> snapshot) throws IOException {
-        StringBuilder sb = new StringBuilder(512);
+    private static void writeJson(Path jsonFile, List<DetectorFinding> snapshot) throws IOException {
+        int count = snapshot.size();
+        StringBuilder sb = new StringBuilder(Math.max(1024, count * 300));
         sb.append("{\n");
         sb.append("  \"asyncTestVersion\": ").append(jsonString(VERSION)).append(",\n");
         sb.append("  \"generatedAt\": ").append(jsonString(Instant.now().toString())).append(",\n");
-        sb.append("  \"totalFindings\": ").append(snapshot.size()).append(",\n");
+        sb.append("  \"totalFindings\": ").append(count).append(",\n");
         sb.append("  \"findings\": [\n");
 
-        for (int i = 0; i < snapshot.size(); i++) {
-            StructuredFinding f = snapshot.get(i);
+        for (int i = 0; i < count; i++) {
+            DetectorFinding f = snapshot.get(i);
             sb.append("    {\n");
             sb.append("      \"detectorName\": ").append(jsonString(f.detectorName)).append(",\n");
-            sb.append("      \"severity\": ").append(jsonString(f.severity)).append(",\n");
+            sb.append("      \"severity\": ").append(jsonString(f.severity.name())).append(",\n");
             sb.append("      \"timestampMs\": ").append(f.timestampMs).append(",\n");
             sb.append("      \"report\": ").append(jsonString(f.report)).append("\n");
             sb.append("    }");
-            if (i < snapshot.size() - 1) sb.append(",");
+            if (i < count - 1) sb.append(",");
             sb.append("\n");
         }
 
@@ -153,18 +152,26 @@ public final class JsonReportListener implements AsyncTestListener {
 
     private static String jsonString(String s) {
         if (s == null) return "null";
-        return "\"" + s.replace("\\", "\\\\")
-                       .replace("\"", "\\\"")
-                       .replace("\n", "\\n")
-                       .replace("\r", "\\r")
-                       .replace("\t", "\\t") + "\"";
+        StringBuilder sb = new StringBuilder(s.length() + 2);
+        sb.append('"');
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\' -> sb.append("\\\\");
+                case '"'  -> sb.append("\\\"");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        sb.append('"');
+        return sb.toString();
     }
-
-    private static String resolveDefaultOutputDir() {
-        if (new File("target").isDirectory()) return "target/async-test-reports";
-        if (new File("build").isDirectory())  return "build/async-test-reports";
-        return "async-test-reports";
-    }
-
-    private record StructuredFinding(String detectorName, String severity, String report, long timestampMs) {}
 }

--- a/src/main/java/se/deversity/asynctest/report/ReportListeners.java
+++ b/src/main/java/se/deversity/asynctest/report/ReportListeners.java
@@ -1,0 +1,14 @@
+package se.deversity.asynctest.report;
+
+import java.io.File;
+
+final class ReportListeners {
+
+    private ReportListeners() {}
+
+    static String resolveDefaultOutputDir() {
+        if (new File("target").isDirectory()) return "target/async-test-reports";
+        if (new File("build").isDirectory())  return "build/async-test-reports";
+        return "async-test-reports";
+    }
+}

--- a/src/test/java/se/deversity/asynctest/report/JUnitXmlReportListenerTest.java
+++ b/src/test/java/se/deversity/asynctest/report/JUnitXmlReportListenerTest.java
@@ -2,6 +2,7 @@ package se.deversity.asynctest.report;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import se.deversity.asynctest.diagnostics.IssueSeverity;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -23,17 +24,18 @@ class JUnitXmlReportListenerTest {
     }
 
     @Test
-    void onDetectorReport_incrementsFindingCount() {
+    void onStructuredReport_incrementsFindingCount() {
         JUnitXmlReportListener listener = new JUnitXmlReportListener(tempDir.toString(), false);
-        listener.onDetectorReport("FalseSharingDetector", "False sharing detected");
-        listener.onDetectorReport("DeadlockDetector", "Deadlock detected");
+        listener.onStructuredReport("FalseSharingDetector", IssueSeverity.HIGH, "False sharing detected");
+        listener.onStructuredReport("DeadlockDetector", IssueSeverity.CRITICAL, "Deadlock detected");
         assertEquals(2, listener.getFindingCount());
     }
 
     @Test
     void flush_writesXmlFile() throws IOException {
         JUnitXmlReportListener listener = new JUnitXmlReportListener(tempDir.toString(), false);
-        listener.onDetectorReport("FalseSharingDetector", "False sharing detected in field 'counter'");
+        listener.onStructuredReport("FalseSharingDetector", IssueSeverity.HIGH,
+            "False sharing detected in field 'counter'");
 
         Path result = listener.flush();
 
@@ -44,7 +46,7 @@ class JUnitXmlReportListenerTest {
     @Test
     void flush_xmlContainsTestsuite() throws IOException {
         JUnitXmlReportListener listener = new JUnitXmlReportListener(tempDir.toString(), false);
-        listener.onDetectorReport("VisibilityMonitor", "Visibility issue detected");
+        listener.onStructuredReport("VisibilityMonitor", IssueSeverity.HIGH, "Visibility issue detected");
 
         Path result = listener.flush();
         String xml = Files.readString(result, StandardCharsets.UTF_8);
@@ -57,7 +59,7 @@ class JUnitXmlReportListenerTest {
     @Test
     void flush_xmlContainsDetectorName() throws IOException {
         JUnitXmlReportListener listener = new JUnitXmlReportListener(tempDir.toString(), false);
-        listener.onDetectorReport("ReentrantLockDetector", "Lock acquired unfairly");
+        listener.onStructuredReport("ReentrantLockDetector", IssueSeverity.HIGH, "Lock acquired unfairly");
 
         Path result = listener.flush();
         String xml = Files.readString(result, StandardCharsets.UTF_8);
@@ -72,7 +74,7 @@ class JUnitXmlReportListenerTest {
     void flush_xmlContainsReportContent() throws IOException {
         JUnitXmlReportListener listener = new JUnitXmlReportListener(tempDir.toString(), false);
         String report = "Thread t1 acquired lock A before lock B, violating established order";
-        listener.onDetectorReport("LockOrderValidator", report);
+        listener.onStructuredReport("LockOrderValidator", IssueSeverity.HIGH, report);
 
         Path result = listener.flush();
         String xml = Files.readString(result, StandardCharsets.UTF_8);
@@ -83,9 +85,9 @@ class JUnitXmlReportListenerTest {
     @Test
     void flush_multipleFindings_allIncluded() throws IOException {
         JUnitXmlReportListener listener = new JUnitXmlReportListener(tempDir.toString(), false);
-        listener.onDetectorReport("DetectorA", "Report A");
-        listener.onDetectorReport("DetectorB", "Report B");
-        listener.onDetectorReport("DetectorC", "Report C");
+        listener.onStructuredReport("DetectorA", IssueSeverity.HIGH, "Report A");
+        listener.onStructuredReport("DetectorB", IssueSeverity.MEDIUM, "Report B");
+        listener.onStructuredReport("DetectorC", IssueSeverity.LOW, "Report C");
 
         Path result = listener.flush();
         String xml = Files.readString(result, StandardCharsets.UTF_8);
@@ -100,12 +102,12 @@ class JUnitXmlReportListenerTest {
     @Test
     void flush_idempotent_secondCallDoesNothing() throws IOException {
         JUnitXmlReportListener listener = new JUnitXmlReportListener(tempDir.toString(), false);
-        listener.onDetectorReport("SomeDetector", "Some report");
+        listener.onStructuredReport("SomeDetector", IssueSeverity.HIGH, "Some report");
 
         Path first = listener.flush();
         assertNotNull(first);
 
-        listener.onDetectorReport("AnotherDetector", "Another report");
+        listener.onStructuredReport("AnotherDetector", IssueSeverity.MEDIUM, "Another report");
         Path second = listener.flush();
         assertNull(second, "Second flush() call should be a no-op");
 
@@ -117,7 +119,7 @@ class JUnitXmlReportListenerTest {
     @Test
     void flush_xmlEscapesSpecialChars() throws IOException {
         JUnitXmlReportListener listener = new JUnitXmlReportListener(tempDir.toString(), false);
-        listener.onDetectorReport("Detector<A>&B\"", "Normal report content");
+        listener.onStructuredReport("Detector<A>&B\"", IssueSeverity.HIGH, "Normal report content");
 
         Path result = listener.flush();
         String xml = Files.readString(result, StandardCharsets.UTF_8);
@@ -127,39 +129,35 @@ class JUnitXmlReportListenerTest {
     }
 
     @Test
-    void severityParsed_criticalInReport() {
-        DetectorFinding finding = new DetectorFinding("D", "🔴 CRITICAL: deadlock imminent", 0L);
-        assertEquals("CRITICAL", finding.severity);
+    void fromReport_critical() {
+        assertEquals(IssueSeverity.CRITICAL, IssueSeverity.fromReport("🔴 CRITICAL: deadlock imminent"));
     }
 
     @Test
-    void severityParsed_highInReport() {
-        DetectorFinding finding = new DetectorFinding("D", "🟠 HIGH: data corruption possible", 0L);
-        assertEquals("HIGH", finding.severity);
+    void fromReport_high() {
+        assertEquals(IssueSeverity.HIGH, IssueSeverity.fromReport("🟠 HIGH: data corruption possible"));
     }
 
     @Test
-    void severityParsed_mediumInReport() {
-        DetectorFinding finding = new DetectorFinding("D", "🟡 MEDIUM: performance issue", 0L);
-        assertEquals("MEDIUM", finding.severity);
+    void fromReport_medium() {
+        assertEquals(IssueSeverity.MEDIUM, IssueSeverity.fromReport("🟡 MEDIUM: performance issue"));
     }
 
     @Test
-    void severityParsed_lowInReport() {
-        DetectorFinding finding = new DetectorFinding("D", "🟢 LOW: minor inefficiency", 0L);
-        assertEquals("LOW", finding.severity);
+    void fromReport_low() {
+        assertEquals(IssueSeverity.LOW, IssueSeverity.fromReport("🟢 LOW: minor inefficiency"));
     }
 
     @Test
-    void severityParsed_unknownDefaultsToHigh() {
-        DetectorFinding finding = new DetectorFinding("D", "Something went wrong", 0L);
-        assertEquals("HIGH", finding.severity);
+    void fromReport_unknownDefaultsToHigh() {
+        assertEquals(IssueSeverity.HIGH, IssueSeverity.fromReport("Something went wrong"));
     }
 
     @Test
     void flush_xmlContainsSeverityInMessage() throws IOException {
         JUnitXmlReportListener listener = new JUnitXmlReportListener(tempDir.toString(), false);
-        listener.onDetectorReport("DeadlockDetector", "🔴 CRITICAL: Thread deadlock detected");
+        listener.onStructuredReport("DeadlockDetector", IssueSeverity.CRITICAL,
+            "🔴 CRITICAL: Thread deadlock detected");
 
         Path result = listener.flush();
         String xml = Files.readString(result, StandardCharsets.UTF_8);


### PR DESCRIPTION
## Summary

- **CI/CD fail gates**: `JUnitXmlReportListener` writes JUnit XML reports parseable by GitHub Actions, Jenkins, and GitLab CI; `StrictModeListener` throws `AssertionError` immediately on any finding
- **Structured JSON output**: `JsonReportListener` writes a machine-readable JSON report consumable by dashboards, quality gates, and custom tooling
- **IntelliJ plugin**: standalone Gradle project under `intellij-plugin/` that reads the JSON report and surfaces findings in a tool window with severity colouring
- **Refactor**: centralised severity parsing (`IssueSeverity.fromReport()`), shared output-dir resolution (`ReportListeners`), `DetectorFinding.severity` promoted to `IssueSeverity`, fixed JSON control-char escaping, right-sized `StringBuilder` allocations

## Commits

- `09d0819` feat(report): add CI/CD-native fail gates for detector findings
- `cb1beed` feat(report): add structured JSON output and onStructuredReport SPI method
- `6c8a1b6` feat(intellij-plugin): add IntelliJ IDEA plugin for in-IDE detector findings
- `55cdf1f` docs: document CI/CD integration, JSON reporting, and IntelliJ plugin
- `57ba31e` refactor(report): eliminate duplicate severity parsing and shared-dir logic

## Test plan

- [ ] `mvn test` passes (52 report/registry tests green)
- [ ] `JUnitXmlReportListenerTest` — 15 tests covering XML structure, escaping, idempotency, severity
- [ ] `JsonReportListenerTest` — 16 tests covering JSON structure, escaping, idempotency, severity
- [ ] `StrictModeListenerTest` — 6 tests
- [ ] `AsyncTestListenerRegistryTest` — includes `fireDetectorReport_alsoNotifiesOnStructuredReport`
- [ ] IntelliJ plugin: `JsonReportParserTest` — 12 pure-Java tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)