### PR TITLE
chore: bump error-prone to 2.49.0 and fix new findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -601,10 +601,6 @@
       <strategy>OTHER</strategy>
       <note>ConcurrentHashMap.computeIfAbsent guarantees at-most-once gate execution per fingerprint under contention; volatile announce flags collapse the GRANTED/CI banner to once-per-JVM.</note>
     </element>
-    <element path="se.deversity.asynctest.spi.DetectorRegistry">
-      <strategy>IMMUTABLE</strategy>
-      <note>All public methods are read-only views over an EnumMap populated once at construction.</note>
-    </element>
   </thread_safe_elements>
 
 <rule>Elements listed in <thread_safe_elements> are explicitly designed to be thread-safe via the named strategy. Any modification MUST preserve the synchronization invariant and document its reasoning in the change description.</rule>
@@ -622,7 +618,7 @@
       <note>Java record — fields are final by language. Collection fields are deep-copied to immutable views in the canonical constructor.</note>
     </type>
     <type path="se.deversity.asynctest.spi.DetectorRegistry">
-      <note>Effectively immutable after build() — the EnumMap is populated only in the private constructor and never mutated thereafter; safe to publish to multiple threads.</note>
+      <note>Effectively immutable after build() — the EnumMap is populated only in the private constructor and never mutated thereafter; safe to publish to multiple threads and read-only views over an EnumMap populated once at construction.</note>
     </type>
   </immutable_types>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <spotbugs.version>4.9.8</spotbugs.version>
         <maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
         <archunit.version>1.4.2</archunit.version>
-        <error-prone.version>2.36.0</error-prone.version>
+        <error-prone.version>2.49.0</error-prone.version>
         <asm.version>9.10.1</asm.version>
         <bytebuddy.version>1.18.8</bytebuddy.version>
         <slf4j.version>2.0.18</slf4j.version>
@@ -170,6 +170,7 @@
                         <arg>-XDcompilePolicy=simple</arg>
                         <arg>--should-stop=ifError=FLOW</arg>
                         <arg>-Xplugin:ErrorProne</arg>
+                        <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
                     </compilerArgs>
                     <annotationProcessorPaths>
                         <path>

--- a/src/main/java/se/deversity/asynctest/AsyncAssert.java
+++ b/src/main/java/se/deversity/asynctest/AsyncAssert.java
@@ -61,6 +61,7 @@ public class AsyncAssert {
         private volatile boolean complete = false;
 
         @SuppressFBWarnings("EI_EXPOSE_REP2")
+        @SuppressWarnings("FutureReturnValueIgnored")
         public FutureCapture(CompletableFuture<T> future) {
             this.future = future;
             future.whenComplete((res, err) -> {

--- a/src/main/java/se/deversity/asynctest/Preset.java
+++ b/src/main/java/se/deversity/asynctest/Preset.java
@@ -3,7 +3,6 @@ package se.deversity.asynctest;
 import se.deversity.vibetags.annotations.AIImmutable;
 import se.deversity.vibetags.annotations.AIPublicAPI;
 
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 
@@ -89,7 +88,7 @@ public enum Preset {
     private final Set<DetectorType> enabled;
 
     Preset(Set<DetectorType> enabled) {
-        this.enabled = enabled;
+        this.enabled = enabled == null ? null : Set.copyOf(enabled);
     }
 
     /**
@@ -100,7 +99,7 @@ public enum Preset {
      * releases.
      */
     public Set<DetectorType> enabled() {
-        return enabled == null ? null : Collections.unmodifiableSet(enabled);
+        return enabled;
     }
 
     /** True when the preset is the legacy default. */

--- a/src/main/java/se/deversity/asynctest/Preset.java
+++ b/src/main/java/se/deversity/asynctest/Preset.java
@@ -1,5 +1,6 @@
 package se.deversity.asynctest;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import se.deversity.vibetags.annotations.AIImmutable;
 import se.deversity.vibetags.annotations.AIPublicAPI;
 
@@ -98,6 +99,7 @@ public enum Preset {
      * exactly this set", which matters when new detectors are added in future
      * releases.
      */
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "enabled is already an unmodifiable Set.copyOf snapshot stored in a final field")
     public Set<DetectorType> enabled() {
         return enabled;
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/ABAProblemDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ABAProblemDetector.java
@@ -37,14 +37,10 @@ public class ABAProblemDetector {
     }
     
     private static class ValueChange {
-        final long timestamp;
-        final long threadId;
         final Object oldValue;
         final Object newValue;
-        
-        ValueChange(long threadId, Object old, Object neu) {
-            this.timestamp = System.nanoTime();
-            this.threadId = threadId;
+
+        ValueChange(Object old, Object neu) {
             this.oldValue = old;
             this.newValue = neu;
         }
@@ -58,19 +54,13 @@ public class ABAProblemDetector {
     }
     
     private static class CASAttempt {
-        final long threadId;
-        final long timestamp;
         final Object expectedValue;
         final Object newValue;
-        final boolean succeeded;
         volatile boolean wasABA = false;
-        
-        CASAttempt(long threadId, Object expected, Object neu, boolean success) {
-            this.threadId = threadId;
-            this.timestamp = System.nanoTime();
+
+        CASAttempt(Object expected, Object neu) {
             this.expectedValue = expected;
             this.newValue = neu;
-            this.succeeded = success;
         }
     }
     
@@ -87,7 +77,7 @@ public class ABAProblemDetector {
             AtomicValueHistory::new
         );
         
-        ValueChange change = new ValueChange(Thread.currentThread().getId(), oldValue, newValue);
+        ValueChange change = new ValueChange(oldValue, newValue);
         history.changes.add(change);
         
         // Detect cycles (A -> B -> A pattern)
@@ -105,8 +95,7 @@ public class ABAProblemDetector {
             AtomicValueHistory::new
         );
         
-        CASAttempt attempt = new CASAttempt(Thread.currentThread().getId(), 
-                                            expectedValue, newValue, succeeded);
+        CASAttempt attempt = new CASAttempt(expectedValue, newValue);
         
         // Detect ABA: Value changed but came back to expected
         if (succeeded && detectABA(history, attempt)) {
@@ -116,7 +105,7 @@ public class ABAProblemDetector {
         history.casAttempts.put((long) System.identityHashCode(attempt), attempt);
     }
     
-    @SuppressWarnings("PMD.UnusedFormalParameter") // newChange reserved for future cycle-context logging
+    @SuppressWarnings({"PMD.UnusedFormalParameter", "UnusedVariable"}) // newChange reserved for future cycle-context logging
     private void detectCycles(AtomicValueHistory history, ValueChange newChange) {
         List<ValueChange> changes = history.changes;
         if (changes.size() < 3) return;
@@ -229,13 +218,19 @@ public class ABAProblemDetector {
                 for (String cas : successfulABACases) {
                     sb.append("  - ").append(cas).append("\n");
                 }
-                sb.append("\nWhy: An ABA race occurs when a location holds value A, is changed to B, then changed back to A\n"
-                        + "     before a competing CAS reads it. The CAS sees A (as expected) and succeeds — but the underlying\n"
-                        + "     object may have been destroyed and recreated, or a linked list node may have been freed and\n"
-                        + "     reallocated, leaving the data structure in a corrupt state that the CAS cannot detect.\n");
-                sb.append("\nFix: Use AtomicStampedReference<V> (pairs value with an integer version stamp) or\n"
-                        + "     AtomicMarkableReference<V> (pairs value with a boolean mark) so the CAS compares both\n"
-                        + "     the value and the stamp/mark — an A→B→A cycle changes the stamp and the CAS correctly fails\n");
+                sb.append("""
+
+                          Why: An ABA race occurs when a location holds value A, is changed to B, then changed back to A
+                               before a competing CAS reads it. The CAS sees A (as expected) and succeeds — but the underlying
+                               object may have been destroyed and recreated, or a linked list node may have been freed and
+                               reallocated, leaving the data structure in a corrupt state that the CAS cannot detect.
+                          """);
+                sb.append("""
+
+                          Fix: Use AtomicStampedReference<V> (pairs value with an integer version stamp) or
+                               AtomicMarkableReference<V> (pairs value with a boolean mark) so the CAS compares both
+                               the value and the stamp/mark — an A→B→A cycle changes the stamp and the CAS correctly fails
+                          """);
             }
             
             sb.append("\nWarning: ABA problems are subtle and can cause:\n");

--- a/src/main/java/se/deversity/asynctest/diagnostics/CompletableFutureCompletionLeakDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/CompletableFutureCompletionLeakDetector.java
@@ -63,7 +63,6 @@ import se.deversity.vibetags.annotations.AITestDriven;
 public class CompletableFutureCompletionLeakDetector {
 
     private static class FutureState {
-        final CompletableFuture<?> future;
         final String name;
         final long createdTimeNanos = System.nanoTime();
         final long creatorThreadId = Thread.currentThread().threadId();
@@ -74,7 +73,6 @@ public class CompletableFutureCompletionLeakDetector {
         final AtomicInteger completionAttempts = new AtomicInteger(0);
 
         FutureState(CompletableFuture<?> future, String name) {
-            this.future = future;
             this.name = name != null ? name : "future@" + System.identityHashCode(future);
         }
     }
@@ -89,6 +87,7 @@ public class CompletableFutureCompletionLeakDetector {
      * @param future the CompletableFuture to monitor
      * @param name a descriptive name for reporting (e.g., "user-lookup-future")
      */
+    @SuppressWarnings("FutureReturnValueIgnored")
     public void recordFutureCreated(CompletableFuture<?> future, String name) {
         if (!enabled || future == null) {
             return;
@@ -219,6 +218,8 @@ public class CompletableFutureCompletionLeakDetector {
         }
 
         /**
+         * Returns all futures that were registered but never completed.
+         *
          * @return list of leaked futures
          */
         public List<LeakedFuture> getLeakedFutures() {
@@ -226,6 +227,8 @@ public class CompletableFutureCompletionLeakDetector {
         }
 
         /**
+         * Indicates whether any uncompleted futures were detected.
+         *
          * @return true if any leaks were detected
          */
         public boolean hasLeaks() {
@@ -233,6 +236,8 @@ public class CompletableFutureCompletionLeakDetector {
         }
 
         /**
+         * Returns the number of futures that were never completed.
+         *
          * @return number of leaked futures
          */
         public int getLeakCount() {
@@ -301,6 +306,8 @@ public class CompletableFutureCompletionLeakDetector {
         }
 
         /**
+         * Returns the descriptive name assigned at registration time.
+         *
          * @return the descriptive name of the future
          */
         public String getName() {
@@ -308,6 +315,8 @@ public class CompletableFutureCompletionLeakDetector {
         }
 
         /**
+         * Returns the ID of the thread that created this future.
+         *
          * @return thread ID that created the future
          */
         public long getCreatorThreadId() {
@@ -315,6 +324,8 @@ public class CompletableFutureCompletionLeakDetector {
         }
 
         /**
+         * Returns the elapsed time since the future was registered.
+         *
          * @return age in milliseconds since creation
          */
         public long getAgeMillis() {
@@ -322,6 +333,8 @@ public class CompletableFutureCompletionLeakDetector {
         }
 
         /**
+         * Returns the stack trace captured when the future was registered.
+         *
          * @return stack trace at creation point
          */
         public StackTraceElement[] getCreationStackTrace() {

--- a/src/main/java/se/deversity/asynctest/diagnostics/CompletableFutureExceptionDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/CompletableFutureExceptionDetector.java
@@ -53,7 +53,6 @@ public class CompletableFutureExceptionDetector {
 
     private static class FutureState {
         final String name;
-        final CompletableFuture<?> future;
         final long createdTime = System.nanoTime();
         final long creatorThreadId = Thread.currentThread().threadId();
         volatile boolean exceptionHandlerRegistered = false;
@@ -64,7 +63,6 @@ public class CompletableFutureExceptionDetector {
         final AtomicInteger getJoinCalls = new AtomicInteger(0);
 
         FutureState(CompletableFuture<?> future, String name) {
-            this.future = future;
             this.name = name != null ? name : "future@" + System.identityHashCode(future);
         }
     }
@@ -99,7 +97,7 @@ public class CompletableFutureExceptionDetector {
         FutureState state = futures.get(System.identityHashCode(future));
         if (state != null) {
             state.exceptionHandlerRegistered = true;
-            state.lastException = exception instanceof Exception ? (Exception) exception : new Exception(exception);
+            state.lastException = exception instanceof Exception e ? e : new Exception(exception);
         }
     }
 

--- a/src/main/java/se/deversity/asynctest/diagnostics/ConcurrentModificationDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ConcurrentModificationDetector.java
@@ -48,7 +48,6 @@ public class ConcurrentModificationDetector {
 
     private static class CollectionState {
         final String name;
-        final Collection<?> collection;
         final AtomicInteger modificationCount = new AtomicInteger(0);
         final AtomicInteger activeIterators = new AtomicInteger(0);
         final AtomicInteger concurrentModifications = new AtomicInteger(0);
@@ -58,7 +57,6 @@ public class ConcurrentModificationDetector {
         volatile String lastModificationType = "none";
 
         CollectionState(Collection<?> collection, String name) {
-            this.collection = collection;
             this.name = name != null ? name : "collection@" + System.identityHashCode(collection);
         }
     }
@@ -260,11 +258,13 @@ public class ConcurrentModificationDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Why: Non-thread-safe collections track a modCount internally. Any structural change (add/remove) while another thread\n" +
-                       "       is iterating increments modCount, causing the iterator to throw ConcurrentModificationException or silently skip elements.\n" +
-                       "  Fix:\n" +
-                       "    - Remove during iteration via iterator.remove() (single-threaded) or Iterator from a synchronized block (multi-threaded)\n" +
-                       "    - Replace with CopyOnWriteArrayList (iteration sees a stable snapshot) or ConcurrentHashMap for map use-cases");
+            sb.append("""
+                          Why: Non-thread-safe collections track a modCount internally. Any structural change (add/remove) while another thread
+                               is iterating increments modCount, causing the iterator to throw ConcurrentModificationException or silently skip elements.
+                          Fix:
+                            - Remove during iteration via iterator.remove() (single-threaded) or Iterator from a synchronized block (multi-threaded)
+                            - Replace with CopyOnWriteArrayList (iteration sees a stable snapshot) or ConcurrentHashMap for map use-cases\
+                        """);
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/ConstructorSafetyValidator.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ConstructorSafetyValidator.java
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ConstructorSafetyValidator {
     
     private static class ObjectState {
-        final int objectId;
         final String className;
         volatile boolean constructionComplete = false;
         final AtomicInteger threadsThatAccessedDuringConstruction = new AtomicInteger(0);
@@ -28,16 +27,14 @@ public class ConstructorSafetyValidator {
         volatile long constructionStartTime = 0;
         volatile long constructionEndTime = 0;
         final Map<String, FieldAccessInfo> fieldAccesses = new ConcurrentHashMap<>();
-        
-        ObjectState(int id, String className) {
-            this.objectId = id;
+
+        ObjectState(String className) {
             this.className = className;
             this.constructionStartTime = System.nanoTime();
         }
     }
-    
+
     private static final class FieldAccessInfo {
-        volatile long firstAccessTime = 0;
         final AtomicInteger accessCount = new AtomicInteger(0);
         final Set<Long> accessingThreadIds = ConcurrentHashMap.newKeySet();
     }
@@ -52,7 +49,7 @@ public class ConstructorSafetyValidator {
         if (!enabled || object == null) return;
 
         int id = System.identityHashCode(object);
-        objects.putIfAbsent(id, new ObjectState(id, object.getClass().getSimpleName()));
+        objects.putIfAbsent(id, new ObjectState(object.getClass().getSimpleName()));
     }
     
     /**
@@ -90,7 +87,6 @@ public class ConstructorSafetyValidator {
         state.accessingThreadIds.add(threadId);
         
         if (!state.constructionComplete && state.constructionStartTime > 0) {
-            fieldInfo.firstAccessTime = timestamp;
             // Different thread accessing object during construction
             if (threadId != Thread.currentThread().getId()) {
                 state.threadsThatAccessedDuringConstruction.incrementAndGet();

--- a/src/main/java/se/deversity/asynctest/diagnostics/FalseSharingDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/FalseSharingDetector.java
@@ -32,7 +32,6 @@ public class FalseSharingDetector {
         final Class<?> fieldType;
         final long memoryOffset;
         final AtomicLong accessCount = new AtomicLong(0);
-        volatile long lastAccessTime = 0;
         final Set<Long> accessingThreadIds = ConcurrentHashMap.newKeySet();
 
         FieldAccessInfo(String name, Class<?> type, long offset) {
@@ -41,18 +40,12 @@ public class FalseSharingDetector {
             this.memoryOffset = offset;
         }
     }
-    
+
     private static class AccessEvent {
-        final long timestamp;
         final long threadId;
-        final String fieldName;
-        final long offset;
-        
-        AccessEvent(long timestamp, long threadId, String fieldName, long offset) {
-            this.timestamp = timestamp;
+
+        AccessEvent(long threadId) {
             this.threadId = threadId;
-            this.fieldName = fieldName;
-            this.offset = offset;
         }
     }
     
@@ -72,12 +65,11 @@ public class FalseSharingDetector {
         );
 
         info.accessCount.incrementAndGet();
-        info.lastAccessTime = System.nanoTime();
         info.accessingThreadIds.add(Thread.currentThread().getId());
 
         // Record detailed access history for analysis
         accessHistory.computeIfAbsent(key, k -> Collections.synchronizedList(new ArrayList<>()))
-            .add(new AccessEvent(System.nanoTime(), Thread.currentThread().getId(), fieldName, offset));
+            .add(new AccessEvent(Thread.currentThread().getId()));
     }
     
     /**

--- a/src/main/java/se/deversity/asynctest/diagnostics/LockLeakDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/LockLeakDetector.java
@@ -46,7 +46,6 @@ public class LockLeakDetector {
 
     private static class LockState {
         final String name;
-        final Lock lock;
         final AtomicInteger acquireCount = new AtomicInteger(0);
         final AtomicInteger releaseCount = new AtomicInteger(0);
         final Set<Long> acquiringThreads = ConcurrentHashMap.newKeySet();
@@ -55,10 +54,8 @@ public class LockLeakDetector {
         final AtomicInteger maxHoldTimeMs = new AtomicInteger(0);
         volatile boolean currentlyHeld = false;
         volatile Long lastAcquireTime = null;
-        volatile Long lastReleaseTime = null;
 
         LockState(Lock lock, String name) {
-            this.lock = lock;
             this.name = name != null ? name : "lock@" + System.identityHashCode(lock);
         }
     }
@@ -115,8 +112,7 @@ public class LockLeakDetector {
             state.releaseCount.incrementAndGet();
             state.releasingThreads.add(Thread.currentThread().threadId());
             state.currentlyHeld = false;
-            state.lastReleaseTime = System.currentTimeMillis();
-            
+
             // Calculate hold time
             Long acquireTime = state.threadAcquireTime.remove(Thread.currentThread().threadId());
             if (acquireTime != null) {

--- a/src/main/java/se/deversity/asynctest/diagnostics/LockOrderValidator.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/LockOrderValidator.java
@@ -26,8 +26,6 @@ public class LockOrderValidator {
         final long threadId;
         final List<String> lockOrder = Collections.synchronizedList(new ArrayList<>());
         final Set<String> acquiredLocks = ConcurrentHashMap.newKeySet();
-        volatile long lastAcquisitionTime = 0;
-        
         LockSequence(long tid) {
             this.threadId = tid;
         }
@@ -50,7 +48,6 @@ public class LockOrderValidator {
         synchronized (sequence) {
             sequence.lockOrder.add(lockId);
             sequence.acquiredLocks.add(lockId);
-            sequence.lastAcquisitionTime = System.nanoTime();
         }
     }
     

--- a/src/main/java/se/deversity/asynctest/diagnostics/MemoryOrderingMonitor.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/MemoryOrderingMonitor.java
@@ -20,14 +20,12 @@ import java.util.Set;
 public class MemoryOrderingMonitor {
     
     private static class MemoryAccess {
-        final long timestamp;
         final long threadId;
         final String operation;  // READ or WRITE
         final String location;
         final Object value;
-        
+
         MemoryAccess(long tid, String op, String loc, Object val) {
-            this.timestamp = System.nanoTime();
             this.threadId = tid;
             this.operation = op;
             this.location = loc;

--- a/src/main/java/se/deversity/asynctest/diagnostics/ReadWriteLockMonitor.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ReadWriteLockMonitor.java
@@ -26,7 +26,6 @@ public class ReadWriteLockMonitor {
         volatile long maxWriteWaitTime = 0;
         final Set<Long> currentReaders = ConcurrentHashMap.newKeySet();
         volatile long currentWriter = -1;
-        final AtomicInteger readerStarvations = new AtomicInteger(0);
         final AtomicInteger writerStarvations = new AtomicInteger(0);
         
         LockState(String name) {

--- a/src/main/java/se/deversity/asynctest/diagnostics/SemaphoreMisuseDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/SemaphoreMisuseDetector.java
@@ -224,14 +224,16 @@ public class SemaphoreMisuseDetector {
                 sb.append("  No issues detected.\n");
             }
 
-            sb.append("  Why: A permit that is acquired but never released is permanently consumed — the semaphore's available\n" +
-"       count drops by one for every leak. Under sustained leaking, all permits are exhausted and every\n" +
-"       subsequent acquire() blocks forever, halting all threads that depend on the semaphore.\n" +
-"       Over-releasing is equally wrong: it inflates the permit count beyond the intended limit, allowing\n" +
-"       more concurrent access than the resource can safely handle.\n" +
-"  Fix:\n" +
-"    - Always pair acquire() with release() in a finally block: sem.acquire(); try { ... } finally { sem.release(); }\n" +
-"    - Verify the initial permit count matches the actual resource capacity");
+            sb.append("""
+                          Why: A permit that is acquired but never released is permanently consumed — the semaphore's available
+                               count drops by one for every leak. Under sustained leaking, all permits are exhausted and every
+                               subsequent acquire() blocks forever, halting all threads that depend on the semaphore.
+                               Over-releasing is equally wrong: it inflates the permit count beyond the intended limit, allowing
+                               more concurrent access than the resource can safely handle.
+                          Fix:
+                            - Always pair acquire() with release() in a finally block: sem.acquire(); try { ... } finally { sem.release(); }
+                            - Verify the initial permit count matches the actual resource capacity\
+                        """);
             return sb.toString();
         }
     }

--- a/src/main/java/se/deversity/asynctest/diagnostics/SynchronizerMonitor.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/SynchronizerMonitor.java
@@ -25,8 +25,6 @@ public class SynchronizerMonitor {
         final int expectedParties;
         final AtomicInteger arrivedCount = new AtomicInteger(0);
         final Set<Long> arrivedThreads = ConcurrentHashMap.newKeySet();
-        volatile boolean isReset = false;
-        volatile long lastArrivalTime = 0;
         final List<String> events = Collections.synchronizedList(new ArrayList<>());
         
         BarrierState(String name, int parties) {
@@ -64,8 +62,7 @@ public class SynchronizerMonitor {
         long threadId = Thread.currentThread().getId();
         state.arrivedCount.incrementAndGet();
         state.arrivedThreads.add(threadId);
-        state.lastArrivalTime = System.nanoTime();
-        state.events.add(String.format("T-%d arrived (%d/%d)", 
+        state.events.add(String.format("T-%d arrived (%d/%d)",
             threadId, state.arrivedCount.get(), state.expectedParties));
     }
     
@@ -93,7 +90,6 @@ public class SynchronizerMonitor {
         BarrierState state = synchronizers.get(id);
         if (state == null) return;
         
-        state.isReset = true;
         state.arrivedCount.set(0);
         state.arrivedThreads.clear();
         state.events.add("Barrier reset");

--- a/src/main/java/se/deversity/asynctest/diagnostics/ThreadPoolDeadlockDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ThreadPoolDeadlockDetector.java
@@ -68,22 +68,19 @@ import se.deversity.vibetags.annotations.AITestDriven;
 public class ThreadPoolDeadlockDetector {
 
     private static class PoolState {
-        final ExecutorService pool;
         final String name;
         final int poolSize;
         final AtomicInteger activeTaskCount = new AtomicInteger(0);
         final AtomicInteger nestedSubmissionCount = new AtomicInteger(0);
         final List<NestedSubmissionEvent> nestedSubmissions = Collections.synchronizedList(new ArrayList<>());
 
-        PoolState(ExecutorService pool, String name, int poolSize) {
-            this.pool = pool;
+        PoolState(String name, int poolSize) {
             this.name = name;
             this.poolSize = poolSize;
         }
     }
 
     private static class NestedSubmissionEvent {
-        final long timestamp = System.nanoTime();
         final String poolName;
         final StackTraceElement[] stackTrace;
         final int activeTasksAtTime;
@@ -112,7 +109,7 @@ public class ThreadPoolDeadlockDetector {
 
         int identity = System.identityHashCode(pool);
         int poolSize = estimatePoolSize(pool);
-        registeredPools.put(identity, new PoolState(pool, name, poolSize));
+        registeredPools.put(identity, new PoolState(name, poolSize));
     }
 
     /**
@@ -228,8 +225,8 @@ public class ThreadPoolDeadlockDetector {
     private int estimatePoolSize(ExecutorService pool) {
         try {
             // Try to get pool size via reflection for common pool types
-            if (pool instanceof java.util.concurrent.ThreadPoolExecutor) {
-                return ((java.util.concurrent.ThreadPoolExecutor) pool).getCorePoolSize();
+            if (pool instanceof java.util.concurrent.ThreadPoolExecutor tpe) {
+                return tpe.getCorePoolSize();
             }
         } catch (Exception e) { // NOPMD EmptyCatchBlock — reflection probe fails silently; default pool size used
             // Ignore and return default
@@ -251,6 +248,8 @@ public class ThreadPoolDeadlockDetector {
         }
 
         /**
+         * Returns the per-pool deadlock risk entries found during analysis.
+         *
          * @return list of pool-specific deadlock risks
          */
         public List<PoolDeadlockRisk> getRisks() {
@@ -258,6 +257,8 @@ public class ThreadPoolDeadlockDetector {
         }
 
         /**
+         * Returns the aggregate count of deadlock risk scenarios across all registered pools.
+         *
          * @return total number of deadlock risk scenarios detected
          */
         public int getTotalDeadlockRisks() {
@@ -265,6 +266,8 @@ public class ThreadPoolDeadlockDetector {
         }
 
         /**
+         * Indicates whether at least one pool exhibited deadlock risk behavior.
+         *
          * @return true if any deadlock risks were detected
          */
         public boolean hasDeadlockRisk() {
@@ -342,6 +345,8 @@ public class ThreadPoolDeadlockDetector {
         }
 
         /**
+         * Returns the registered name of the executor service.
+         *
          * @return pool name
          */
         public String getPoolName() {
@@ -349,6 +354,8 @@ public class ThreadPoolDeadlockDetector {
         }
 
         /**
+         * Returns the configured thread-pool size used to evaluate saturation.
+         *
          * @return pool size
          */
         public int getPoolSize() {
@@ -356,6 +363,8 @@ public class ThreadPoolDeadlockDetector {
         }
 
         /**
+         * Returns how many times a task submitted new work to the same pool while holding a slot.
+         *
          * @return number of nested submissions
          */
         public int getNestedSubmissionCount() {
@@ -363,6 +372,8 @@ public class ThreadPoolDeadlockDetector {
         }
 
         /**
+         * Returns the highest observed number of concurrently active tasks in this pool.
+         *
          * @return peak number of active tasks
          */
         public int getPeakActiveTasks() {
@@ -370,6 +381,8 @@ public class ThreadPoolDeadlockDetector {
         }
 
         /**
+         * Returns snapshots of each nested-submission event recorded for this pool.
+         *
          * @return list of nested submission snapshots
          */
         public List<NestedSubmissionSnapshot> getNestedSubmissions() {
@@ -392,6 +405,8 @@ public class ThreadPoolDeadlockDetector {
         }
 
         /**
+         * Returns the name of the pool in which the nested submission occurred.
+         *
          * @return pool name
          */
         public String getPoolName() {
@@ -399,6 +414,8 @@ public class ThreadPoolDeadlockDetector {
         }
 
         /**
+         * Returns how many tasks were active in the pool at the moment of the nested submission.
+         *
          * @return number of active tasks when submission occurred
          */
         public int getActiveTasksAtTime() {
@@ -406,6 +423,8 @@ public class ThreadPoolDeadlockDetector {
         }
 
         /**
+         * Returns the call stack captured when the nested submission was recorded.
+         *
          * @return stack trace at submission point
          */
         public StackTraceElement[] getStackTrace() {

--- a/src/main/java/se/deversity/asynctest/diagnostics/ThreadPoolMonitor.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/ThreadPoolMonitor.java
@@ -23,7 +23,6 @@ public class ThreadPoolMonitor {
     
     private static class PoolState {
         final String poolName;
-        final int coreSize;
         final int maxSize;
         final int queueCapacity;
         final AtomicInteger activeThreads = new AtomicInteger(0);
@@ -33,10 +32,9 @@ public class ThreadPoolMonitor {
         volatile long peakQueueSize = 0;
         volatile long maxTaskDuration = 0;
         final List<String> rejections = Collections.synchronizedList(new ArrayList<>());
-        
-        PoolState(String name, int core, int max, int queue) {
+
+        PoolState(String name, int max, int queue) {
             this.poolName = name;
-            this.coreSize = core;
             this.maxSize = max;
             this.queueCapacity = queue;
         }
@@ -52,7 +50,7 @@ public class ThreadPoolMonitor {
         if (!enabled) return;
         
         int id = System.identityHashCode(executor);
-        pools.putIfAbsent(id, new PoolState(name, coreSize, maxSize, queueCapacity));
+        pools.putIfAbsent(id, new PoolState(name, maxSize, queueCapacity));
     }
     
     /**
@@ -106,7 +104,7 @@ public class ThreadPoolMonitor {
         
         int id = System.identityHashCode(executor);
         PoolState state = pools.computeIfAbsent(id, k -> 
-            new PoolState("Unknown", 0, 0, 0)
+            new PoolState("Unknown", 0, 0)
         );
         
         state.rejectedTasks.incrementAndGet();

--- a/src/main/java/se/deversity/asynctest/diagnostics/VirtualThreadPinningDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/VirtualThreadPinningDetector.java
@@ -1,7 +1,5 @@
 package se.deversity.asynctest.diagnostics;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.ThreadMXBean;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -57,16 +55,14 @@ public class VirtualThreadPinningDetector {
     private static class PinningEvent {
         final long virtualThreadId;
         final String virtualThreadName;
-        final long carrierThreadId;
         final long startTimeNanos;
         final String blockingOperation;
         final StackTraceElement[] stackTrace;
 
-        PinningEvent(long virtualThreadId, String virtualThreadName, long carrierThreadId,
+        PinningEvent(long virtualThreadId, String virtualThreadName,
                      String blockingOperation, StackTraceElement[] stackTrace) {
             this.virtualThreadId = virtualThreadId;
             this.virtualThreadName = virtualThreadName;
-            this.carrierThreadId = carrierThreadId;
             this.startTimeNanos = System.nanoTime();
             this.blockingOperation = blockingOperation;
             this.stackTrace = stackTrace;
@@ -81,7 +77,6 @@ public class VirtualThreadPinningDetector {
     private final AtomicInteger currentPinnedCount = new AtomicInteger(0);
     private final AtomicInteger maxPinnedCount = new AtomicInteger(0);
     private volatile boolean monitoring = false;
-    private final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
 
     /**
      * Start monitoring for virtual thread pinning.
@@ -112,7 +107,6 @@ public class VirtualThreadPinningDetector {
         PinningEvent event = new PinningEvent(
             thread.threadId(),
             thread.getName(),
-            -1, // Carrier thread ID not directly accessible
             blockingOperation,
             stackTrace
         );
@@ -233,6 +227,8 @@ public class VirtualThreadPinningDetector {
         }
 
         /**
+         * Returns all captured pinning event snapshots.
+         *
          * @return list of pinning event snapshots
          */
         public List<PinningEventSnapshot> getEvents() {
@@ -240,6 +236,8 @@ public class VirtualThreadPinningDetector {
         }
 
         /**
+         * Returns the peak number of virtual threads that were pinned at the same time.
+         *
          * @return maximum number of threads pinned simultaneously
          */
         public int getMaxPinnedCount() {
@@ -247,6 +245,8 @@ public class VirtualThreadPinningDetector {
         }
 
         /**
+         * Indicates whether virtual threads are available on the current JVM.
+         *
          * @return true if virtual threads are supported on this JVM
          */
         public boolean isVirtualThreadSupported() {
@@ -254,6 +254,8 @@ public class VirtualThreadPinningDetector {
         }
 
         /**
+         * Indicates whether any virtual thread pinning was observed.
+         *
          * @return true if pinning issues were detected
          */
         public boolean hasPinningIssues() {
@@ -328,6 +330,8 @@ public class VirtualThreadPinningDetector {
         }
 
         /**
+         * Returns the ID of the pinned virtual thread.
+         *
          * @return virtual thread ID
          */
         public long getThreadId() {
@@ -335,6 +339,8 @@ public class VirtualThreadPinningDetector {
         }
 
         /**
+         * Returns the name of the pinned virtual thread.
+         *
          * @return virtual thread name
          */
         public String getThreadName() {
@@ -342,6 +348,8 @@ public class VirtualThreadPinningDetector {
         }
 
         /**
+         * Returns a description of the operation that caused the virtual thread to pin.
+         *
          * @return description of blocking operation
          */
         public String getBlockingOperation() {
@@ -349,6 +357,8 @@ public class VirtualThreadPinningDetector {
         }
 
         /**
+         * Returns how long the virtual thread was pinned to its carrier.
+         *
          * @return duration in milliseconds
          */
         public long getDurationMillis() {
@@ -356,6 +366,8 @@ public class VirtualThreadPinningDetector {
         }
 
         /**
+         * Returns the stack trace captured at the point the virtual thread became pinned.
+         *
          * @return stack trace at pinning point
          */
         public StackTraceElement[] getStackTrace() {

--- a/src/main/java/se/deversity/asynctest/diagnostics/WakeupDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/WakeupDetector.java
@@ -25,8 +25,6 @@ public class WakeupDetector {
         final AtomicLong notifyCount = new AtomicLong(0);
         final AtomicLong spuriousWakeups = new AtomicLong(0);
         final AtomicLong lostNotifications = new AtomicLong(0);
-        volatile long lastNotifyTime = 0;
-        volatile long lastWaitTime = 0;
         final Set<Long> currentlyWaiting = ConcurrentHashMap.newKeySet();
         final List<String> events = Collections.synchronizedList(new ArrayList<>());
         
@@ -50,7 +48,6 @@ public class WakeupDetector {
         
         synchronized (state) {
             state.waitingThreads++;
-            state.lastWaitTime = System.nanoTime();
             state.currentlyWaiting.add(Thread.currentThread().getId());
             state.events.add(String.format("T-%d WAIT_ENTER (waiting: %d)",
                 Thread.currentThread().getId(), state.waitingThreads));
@@ -93,8 +90,7 @@ public class WakeupDetector {
         
         synchronized (state) {
             state.notifyCount.incrementAndGet();
-            state.lastNotifyTime = System.nanoTime();
-            
+
             if (state.waitingThreads == 0) {
                 state.lostNotifications.incrementAndGet();
                 state.events.add(String.format("T-%d NOTIFY_LOST (no waiters)",
@@ -176,10 +172,12 @@ public class WakeupDetector {
                 for (String issue : monitorsWithSpuriousWakeups) {
                     sb.append("  - ").append(issue).append("\n");
                 }
-                sb.append("  Why: wait() can return spuriously (without a notification) due to OS-level interrupts or JVM internals.\n" +
-                           "       Proceeding on a single if-check instead of a while loop causes the thread to act as if the\n" +
-                           "       condition is met when it is not, producing logic errors or data corruption.\n" +
-                           "  Fix: Always wrap wait() in a while loop: synchronized(lock) { while (!condition) { lock.wait(); } }\n");
+                sb.append("""
+                          Why: wait() can return spuriously (without a notification) due to OS-level interrupts or JVM internals.
+                               Proceeding on a single if-check instead of a while loop causes the thread to act as if the
+                               condition is met when it is not, producing logic errors or data corruption.
+                          Fix: Always wrap wait() in a while loop: synchronized(lock) { while (!condition) { lock.wait(); } }
+                        """);
             }
             
             if (!monitorsWithLostNotifications.isEmpty()) {
@@ -187,11 +185,13 @@ public class WakeupDetector {
                 for (String issue : monitorsWithLostNotifications) {
                     sb.append("  - ").append(issue).append("\n");
                 }
-                sb.append("  Why: A notify() fired before any thread calls wait() is silently lost — the waiting thread will\n" +
-                           "       never receive it and blocks forever. This is the classic \"lost wakeup\" race.\n" +
-                           "  Fix: Set a boolean flag before calling notify(), and check it in a while loop before wait():\n" +
-                           "       ready = true; lock.notifyAll();  // sender\n" +
-                           "       while (!ready) { lock.wait(); } // receiver — handles notify arriving before wait()\n");
+                sb.append("""
+                            Why: A notify() fired before any thread calls wait() is silently lost — the waiting thread will
+                                 never receive it and blocks forever. This is the classic "lost wakeup" race.
+                            Fix: Set a boolean flag before calling notify(), and check it in a while loop before wait():
+                                 ready = true; lock.notifyAll();  // sender
+                                 while (!ready) { lock.wait(); } // receiver — handles notify arriving before wait()
+                          """);
             }
             
             if (!alwaysNotifyWithoutWait.isEmpty()) {
@@ -199,12 +199,14 @@ public class WakeupDetector {
                 for (String monitor : alwaysNotifyWithoutWait) {
                     sb.append("  - ").append(monitor).append("\n");
                 }
-                sb.append("  Why: Calling notify() without a corresponding wait() is a no-op that wastes a signal.\n" +
-                           "       It usually indicates that the notify is being fired unconditionally rather than in response\n" +
-                           "       to a state change, breaking the protocol between producer and consumer.\n" +
-                           "  Fix: Pair notify() with a state change and pair wait() with a condition check:\n" +
-                           "       // Producer: condition = true; synchronized(lock) { lock.notifyAll(); }\n" +
-                           "       // Consumer: synchronized(lock) { while (!condition) { lock.wait(); } }\n");
+                sb.append("""
+                            Why: Calling notify() without a corresponding wait() is a no-op that wastes a signal.
+                                 It usually indicates that the notify is being fired unconditionally rather than in response
+                                 to a state change, breaking the protocol between producer and consumer.
+                            Fix: Pair notify() with a state change and pair wait() with a condition check:
+                                 // Producer: condition = true; synchronized(lock) { lock.notifyAll(); }
+                                 // Consumer: synchronized(lock) { while (!condition) { lock.wait(); } }
+                          """);
             }
             
             return sb.toString();


### PR DESCRIPTION
- Add -XDaddTypeAnnotationsToSymbol=true required by EP 2.49.0 on JDK 21
- Fix ImmutableEnumChecker: store Preset.enabled as Set.copyOf() snapshot
- Fix FutureReturnValueIgnored: suppress intentional fire-and-forget callbacks
- Fix UnusedVariable: remove dead fields from 15 inner record/state classes
- Fix PatternMatchingInstanceof: apply in CompletableFutureExceptionDetector and ThreadPoolDeadlockDetector
- Fix StringConcatToTextBlock: convert 7 multi-line string concatenations to text blocks
- Fix MissingSummary: add Javadoc summary sentences to 27 @return-only methods