### PR TITLE
feat: includes/failOn attributes, class-level @AsyncTest, findings ba…

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ Full parameter reference: [docs/USAGE.md](docs/USAGE.md)
     virtualThreadStressMode = "HIGH",        // OFF / LOW / MEDIUM / HIGH / EXTREME
     preset       = Preset.ESSENTIALS,        // curated detector bundle (overrides detectAll)
     detectAll    = true,                     // legacy umbrella when preset = ALL
-    excludes     = { DetectorType.FALSE_SHARING },  // prune even from a preset
+    includes     = { DetectorType.DEADLOCKS },      // OR: exactly these detectors, nothing else
+    excludes     = { DetectorType.FALSE_SHARING },  // prune even from a preset/includes
+    failOn       = FailOn.HIGH,              // findings at/above this severity fail the test
     replaySeed   = 0L                        // 0 = fresh per round; set on failure to reproduce
 )
 ```
@@ -166,8 +168,33 @@ Full parameter reference: [docs/USAGE.md](docs/USAGE.md)
 | `useVirtualThreads` | true | Use `Thread.ofVirtual()` (Java 21+) |
 | `preset` | `Preset.ALL` | Curated bundle: `ALL` / `STRICT` / `ESSENTIALS` / `CI_FAST` / `NONE` |
 | `detectAll` | true | Enable all detectors in one shot (honored when `preset = ALL`) |
-| `excludes` | `{}` | Detectors to skip — layers on top of any preset |
+| `includes` | `{}` | Enable exactly these detectors — overrides `preset`/`detectAll`/per-detector flags when non-empty |
+| `excludes` | `{}` | Detectors to skip — layers on top of any preset or `includes` and wins on conflict |
+| `failOn` | `FailOn.NONE` | Severity gate: findings at/above this level (`LOW`/`MEDIUM`/`HIGH`/`CRITICAL`) fail the test; `NONE` = report-only |
 | `replaySeed` | 0 | Per-round RNG seed. `0` = fresh per round (printed on failure); set explicitly to reproduce a failing schedule |
+
+`@AsyncTest` can also be placed on a **class** (shared config for all `@TestTemplate`
+methods; method-level `@AsyncTest` wins) or on an **annotation** to compose reusable
+presets like `@EssentialsAsyncTest`.
+
+### Fail gates & baseline
+
+Gate CI on serious findings while adopting incrementally:
+
+```java
+@AsyncTest(failOn = FailOn.HIGH)   // HIGH and CRITICAL findings fail the test
+void checkout_concurrently() { ... }
+```
+
+For a legacy codebase, record the current findings once and ratchet them down:
+
+```bash
+mvn test -Dasync-test.baseline=async-test-baseline.txt -Dasync-test.baseline.update=true  # record
+mvn test -Dasync-test.baseline=async-test-baseline.txt                                    # enforce
+```
+
+Each baseline line is `com.example.MyTest#method | DetectorName` — diff-friendly and
+hand-editable; delete lines as you fix the findings.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Detector selection & fail-gating (`@AsyncTest` extensions)
+
+- **`@AsyncTest(includes = {DetectorType...})`** — enable exactly the listed
+  detectors and nothing else. Takes precedence over `preset` / `detectAll` /
+  the legacy per-detector booleans; `excludes` still layers on top and wins on
+  conflict. Also available programmatically via
+  `AsyncTestConfig.Builder.includes(...)`. Prefer `preset` / `includes` /
+  `excludes` over the ~98 per-detector boolean attributes.
+
+- **Class-level and composed `@AsyncTest`** — `@Target` now includes `TYPE`
+  and `ANNOTATION_TYPE`:
+  - a class-level `@AsyncTest` provides shared configuration for every
+    `@TestTemplate` method in the class (a method-level `@AsyncTest` wins);
+  - reusable composed annotations are now possible, e.g.
+    `@AsyncTest(preset = Preset.ESSENTIALS) public @interface EssentialsAsyncTest {}`.
+  `AsyncTestExtension` resolves the annotation meta-aware (method first, then
+  class) via `AnnotationSupport.findAnnotation`.
+
+- **`@AsyncTest(failOn = FailOn.X)`** — severity threshold at or above which
+  detector findings fail the test (`NONE` / `LOW` / `MEDIUM` / `HIGH` /
+  `CRITICAL`). The runner now analyzes all enabled detectors **after a passing
+  run too** (previously findings only surfaced when the test body had already
+  failed or timed out), prints reports, and fires them to registered
+  listeners — so `JUnitXmlReportListener` / `JsonReportListener` /
+  `StrictModeListener` now see findings from passing tests. The default
+  `FailOn.NONE` preserves the legacy report-only behavior.
+
+- **Known-findings baseline** (`se.deversity.asynctest.report.Baseline`) —
+  adopt fail-gating on a legacy codebase without a red wall:
+  - `-Dasync-test.baseline=<file>` suppresses baselined findings from the
+    `failOn` gate (one diff-friendly line per finding:
+    `com.example.MyTest#method | DetectorName`);
+  - `-Dasync-test.baseline.update=true` records gate-failing findings into the
+    file instead of failing, so the baseline can be generated in one run and
+    ratcheted down over time.
+
 ### Production Readiness Pass
 
 #### Added

--- a/src/main/java/se/deversity/asynctest/AsyncTest.java
+++ b/src/main/java/se/deversity/asynctest/AsyncTest.java
@@ -20,10 +20,33 @@ import java.lang.annotation.Target;
  * - Visibility issues (missing volatile keywords)
  * - Livelocks and thread starvation
  * - Virtual thread pinning issues (Java 21+)
+ *
+ * <h2>Placement</h2>
+ * <ul>
+ *   <li><b>Method</b> — the standard usage; the method becomes an async stress test.</li>
+ *   <li><b>Class</b> — provides shared configuration for every method in the class
+ *       annotated with {@link org.junit.jupiter.api.TestTemplate}. A method-level
+ *       {@code @AsyncTest} always takes precedence over the class-level one.</li>
+ *   <li><b>Annotation</b> — compose your own reusable annotation, e.g.
+ *       <pre>{@code
+ *       @Retention(RetentionPolicy.RUNTIME)
+ *       @Target(ElementType.METHOD)
+ *       @AsyncTest(preset = Preset.ESSENTIALS, threads = 8)
+ *       public @interface EssentialsAsyncTest {}
+ *       }</pre>
+ *       Composed annotations carry a fixed configuration; their attributes cannot be
+ *       overridden at the use site.</li>
+ * </ul>
+ *
+ * <h2>Selecting detectors</h2>
+ * Prefer {@link #preset()}, {@link #includes()}, and {@link #excludes()} over the
+ * legacy per-detector boolean attributes — they express the same intent without
+ * dozens of flags and are the only mechanisms new detector categories are
+ * guaranteed to support ergonomically.
  */
 @AIContract(reason = "Public annotation API used directly in user test methods. Attribute names, types, and defaults are part of the stable public API — any change is a breaking change for all consumers.")
 @AIPublicAPI
-@Target({ElementType.METHOD})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @TestTemplate
 @ExtendWith(se.deversity.asynctest.extension.AsyncTestExtension.class)
@@ -173,6 +196,47 @@ public @interface AsyncTest {
      * <p>Example: {@code @AsyncTest(detectAll = true, excludes = {DetectorType.BUSY_WAITING})}
      */
     DetectorType[] excludes() default {};
+
+    /**
+     * Enable exactly the listed detectors and nothing else.
+     *
+     * <p>When non-empty, this attribute takes precedence over {@link #preset()},
+     * {@link #detectAll()}, and the legacy per-detector boolean attributes: only
+     * the listed {@link DetectorType}s are active. {@link #excludes()} still
+     * applies on top and wins on conflict.
+     *
+     * <p>Example: {@code @AsyncTest(includes = {DetectorType.DEADLOCKS, DetectorType.RACE_CONDITIONS})}
+     * — only deadlock and race-condition detection, expressed in one attribute
+     * instead of {@code detectAll = false} plus individual flags.
+     *
+     * <p>Default empty array means "no opinion" — {@link #preset()} /
+     * {@link #detectAll()} semantics apply unchanged.
+     *
+     * @since 1.7.0
+     */
+    DetectorType[] includes() default {};
+
+    /**
+     * Severity threshold at or above which detector findings fail this test.
+     *
+     * <p>After the N×M run completes, every enabled detector is analyzed.
+     * Findings at or above this threshold throw an {@link AssertionError};
+     * findings below it are printed and fired to registered
+     * {@link AsyncTestListener}s but do not fail the test.
+     *
+     * <p>The default {@link FailOn#NONE} preserves the legacy report-only
+     * behavior. Set {@code failOn = FailOn.HIGH} in CI to gate merges on
+     * serious findings while still surfacing lower-severity ones.
+     *
+     * <p>Known findings can be suppressed via a baseline file:
+     * {@code -Dasync-test.baseline=<path>} to apply,
+     * {@code -Dasync-test.baseline.update=true} to record current findings
+     * instead of failing. Each baseline line is
+     * {@code com.example.MyTest#myMethod | DetectorName}.
+     *
+     * @since 1.7.0
+     */
+    FailOn failOn() default FailOn.NONE;
 
     // ============= Phase 2: Advanced Detectors =============
 

--- a/src/main/java/se/deversity/asynctest/AsyncTestConfig.java
+++ b/src/main/java/se/deversity/asynctest/AsyncTestConfig.java
@@ -42,6 +42,13 @@ public final class AsyncTestConfig {
      */
     public final long replaySeed;
 
+    /**
+     * Severity threshold at or above which detector findings fail the test.
+     * {@link FailOn#NONE} (default) keeps the legacy report-only behavior.
+     * @since 1.7.0
+     */
+    public final FailOn failOn;
+
     // ---- Phase 1 ----
     public final boolean detectDeadlocks;
     public final boolean detectVisibility;
@@ -201,6 +208,7 @@ public final class AsyncTestConfig {
         virtualThreadStressMode        = b.virtualThreadStressMode;
         detectAll                      = b.detectAll;
         replaySeed                     = b.replaySeed;
+        failOn                         = b.failOn;
         detectDeadlocks                = b.detectDeadlocks;
         detectVisibility               = b.detectVisibility;
         detectLivelocks                = b.detectLivelocks;
@@ -337,15 +345,25 @@ public final class AsyncTestConfig {
         // Check for global benchmarking system property
         boolean globalBenchmarkingEnabled = Boolean.getBoolean("async-test.benchmarking.enabled");
 
-        // Resolve preset → effective detectAll + excludes set.
-        // ALL/STRICT preserve the legacy detectAll behavior; other presets force
-        // detectAll = true but exclude every DetectorType outside the preset's
-        // enabled set so that build()'s detectAll loop activates only the
-        // selected detectors. User-supplied excludes() always layer on top.
+        // Resolve includes/preset → effective detectAll + excludes set.
+        // A non-empty includes() is the most specific selection and wins over
+        // preset() and detectAll(): detectAll is forced true and every
+        // DetectorType outside the include set is excluded, so build()'s
+        // detectAll loop activates only the listed detectors. Otherwise
+        // ALL/STRICT preserve the legacy detectAll behavior, and other presets
+        // exclude everything outside the preset's enabled set the same way.
+        // User-supplied excludes() always layer on top and win on conflict.
         Preset preset = ann.preset();
         boolean effectiveDetectAll;
         Set<DetectorType> effectiveExcludes = EnumSet.noneOf(DetectorType.class);
-        if (preset.isAll()) {
+        if (ann.includes().length > 0) {
+            effectiveDetectAll = true;
+            Set<DetectorType> included = EnumSet.noneOf(DetectorType.class);
+            included.addAll(Arrays.asList(ann.includes()));
+            for (DetectorType t : DetectorType.values()) {
+                if (!included.contains(t)) effectiveExcludes.add(t);
+            }
+        } else if (preset.isAll()) {
             effectiveDetectAll = ann.detectAll();
         } else {
             effectiveDetectAll = true;
@@ -364,6 +382,7 @@ public final class AsyncTestConfig {
             .virtualThreadStressMode(ann.virtualThreadStressMode())
             .detectAll(effectiveDetectAll)
             .replaySeed(ann.replaySeed())
+            .failOn(ann.failOn())
             .detectDeadlocks(ann.detectDeadlocks())
             .detectVisibility(ann.detectVisibility())
             .detectLivelocks(ann.detectLivelocks())
@@ -495,6 +514,7 @@ public final class AsyncTestConfig {
         private String virtualThreadStressMode     = "OFF";
         private boolean detectAll                  = false;
         private long    replaySeed                 = 0L;
+        private FailOn  failOn                     = FailOn.NONE;
         private boolean detectDeadlocks            = true;
         private boolean detectVisibility           = false;
         private boolean detectLivelocks            = false;
@@ -613,6 +633,7 @@ public final class AsyncTestConfig {
         private String licenseKey = "";
         private boolean licenseMockMode = false;
         private Set<DetectorType> excludes = EnumSet.noneOf(DetectorType.class);
+        private Set<DetectorType> includes = EnumSet.noneOf(DetectorType.class);
 
         public Builder threads(int v)                        { threads = v; return this; }
         public Builder invocations(int v)                    { invocations = v; return this; }
@@ -621,6 +642,7 @@ public final class AsyncTestConfig {
         public Builder virtualThreadStressMode(String v)     { virtualThreadStressMode = v; return this; }
         public Builder detectAll(boolean v)                  { detectAll = v; return this; }
         public Builder replaySeed(long v)                    { replaySeed = v; return this; }
+        public Builder failOn(FailOn v)                      { failOn = (v != null) ? v : FailOn.NONE; return this; }
         public Builder detectDeadlocks(boolean v)            { detectDeadlocks = v; return this; }
         public Builder detectVisibility(boolean v)           { detectVisibility = v; return this; }
         public Builder detectLivelocks(boolean v)            { detectLivelocks = v; return this; }
@@ -744,7 +766,33 @@ public final class AsyncTestConfig {
             return this;
         }
 
+        /**
+         * Enable exactly the listed detectors and nothing else. Mirrors
+         * {@link AsyncTest#includes()}: when non-empty it overrides
+         * {@link #detectAll(boolean)} and the per-detector setters;
+         * {@link #excludes(DetectorType[])} still layers on top.
+         *
+         * @since 1.7.0
+         */
+        public Builder includes(DetectorType[] v) {
+            if (v != null && v.length > 0) {
+                this.includes.addAll(Arrays.asList(v));
+            }
+            return this;
+        }
+
         public AsyncTestConfig build() {
+            if (!includes.isEmpty()) {
+                // includes wins over detectAll/per-flag setters: force the
+                // detectAll path and exclude everything outside the include set.
+                // Explicit excludes are already in the set and thus still win.
+                detectAll = true;
+                for (DetectorType t : DetectorType.values()) {
+                    if (!includes.contains(t)) {
+                        excludes.add(t);
+                    }
+                }
+            }
             if (detectAll) {
                 if (!excludes.contains(DetectorType.DEADLOCKS)) detectDeadlocks = true;
                     else detectDeadlocks = false;

--- a/src/main/java/se/deversity/asynctest/FailOn.java
+++ b/src/main/java/se/deversity/asynctest/FailOn.java
@@ -1,0 +1,56 @@
+package se.deversity.asynctest;
+
+import se.deversity.asynctest.diagnostics.IssueSeverity;
+
+/**
+ * Severity threshold at or above which detector findings fail an {@code @AsyncTest}.
+ *
+ * <p>Used by {@link AsyncTest#failOn()}. After a test run completes, every enabled
+ * detector is analyzed; findings whose {@link IssueSeverity} meets this threshold
+ * cause the test to fail with an {@link AssertionError}. Findings below the
+ * threshold are still printed and fired to registered
+ * {@link AsyncTestListener}s, but do not fail the test.
+ *
+ * <p>{@link #NONE} (the default) preserves the legacy report-only behavior:
+ * findings never fail the test by themselves.
+ *
+ * @since 1.7.0
+ */
+public enum FailOn {
+
+    /** Never fail on detector findings (report-only mode, legacy default). */
+    NONE,
+
+    /** Fail on any finding ({@code LOW} and above). */
+    LOW,
+
+    /** Fail on {@code MEDIUM}, {@code HIGH}, and {@code CRITICAL} findings. */
+    MEDIUM,
+
+    /** Fail on {@code HIGH} and {@code CRITICAL} findings. */
+    HIGH,
+
+    /** Fail only on {@code CRITICAL} findings. */
+    CRITICAL;
+
+    /**
+     * Returns {@code true} when a finding of the given severity meets this threshold.
+     *
+     * @param severity the severity of a detector finding; {@code null} returns {@code false}
+     * @return whether the finding should fail the test
+     */
+    public boolean triggeredBy(IssueSeverity severity) {
+        if (this == NONE || severity == null) {
+            return false;
+        }
+        // IssueSeverity declares CRITICAL(0) .. LOW(3); lower ordinal = more severe.
+        int worstAccepted = switch (this) {
+            case LOW      -> 3;
+            case MEDIUM   -> 2;
+            case HIGH     -> 1;
+            case CRITICAL -> 0;
+            case NONE     -> -1; // unreachable
+        };
+        return severity.ordinal() <= worstAccepted;
+    }
+}

--- a/src/main/java/se/deversity/asynctest/diagnostics/Phase1DetectorSet.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/Phase1DetectorSet.java
@@ -3,6 +3,9 @@ package se.deversity.asynctest.diagnostics;
 import se.deversity.asynctest.AsyncTestConfig;
 import se.deversity.asynctest.AsyncTestListenerRegistry;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
  * Groups all Phase 1 detector instances for a single test run.
  *
@@ -63,61 +66,52 @@ public final class Phase1DetectorSet {
      * {@link se.deversity.asynctest.runner.ConcurrencyRunner}.
      */
     public void printReports() {
+        for (Map.Entry<String, String> e : collectReports().entrySet()) {
+            System.err.println(e.getValue());
+            AsyncTestListenerRegistry.fireDetectorReport(e.getKey(), e.getValue());
+        }
+    }
+
+    /**
+     * Analyzes every enabled Phase 1 detector and returns the reports of those
+     * with issues, keyed by detector name, in stable declaration order.
+     *
+     * <p>Unlike {@link #printReports()} this performs no printing or listener
+     * firing — used by the runner's success-path {@code failOn} gate, which
+     * needs the reports as data before deciding whether to fail the test.
+     *
+     * @since 1.7.0
+     */
+    public Map<String, String> collectReports() {
+        Map<String, String> out = new LinkedHashMap<>();
         if (visibility != null) {
             VisibilityMonitor.VisibilityReport r = visibility.analyzeVisibility();
-            if (r.hasIssues()) {
-                String report = "\n" + r;
-                System.err.println(report);
-                AsyncTestListenerRegistry.fireDetectorReport("VisibilityMonitor", report);
-            }
+            if (r.hasIssues()) out.put("VisibilityMonitor", "\n" + r);
         }
         if (livelock != null) {
             LivelockDetector.LivelockReport r = livelock.analyzeLivelocks();
-            if (r.hasIssues()) {
-                String report = "\n" + r;
-                System.err.println(report);
-                AsyncTestListenerRegistry.fireDetectorReport("LivelockDetector", report);
-            }
+            if (r.hasIssues()) out.put("LivelockDetector", "\n" + r);
         }
         if (race != null) {
             RaceConditionDetector.RaceConditionReport r = race.analyzeRaceConditions();
-            if (r.hasIssues()) {
-                String report = "\n" + r;
-                System.err.println(report);
-                AsyncTestListenerRegistry.fireDetectorReport("RaceConditionDetector", report);
-            }
+            if (r.hasIssues()) out.put("RaceConditionDetector", "\n" + r);
         }
         if (threadLocal != null) {
             ThreadLocalMonitor.ThreadLocalReport r = threadLocal.analyzeThreadLocalLeaks();
-            if (r.hasIssues()) {
-                String report = "\n" + r;
-                System.err.println(report);
-                AsyncTestListenerRegistry.fireDetectorReport("ThreadLocalMonitor", report);
-            }
+            if (r.hasIssues()) out.put("ThreadLocalMonitor", "\n" + r);
         }
         if (busyWait != null) {
             BusyWaitDetector.BusyWaitReport r = busyWait.analyzeBusyWaiting();
-            if (r.hasIssues()) {
-                String report = "\n" + r;
-                System.err.println(report);
-                AsyncTestListenerRegistry.fireDetectorReport("BusyWaitDetector", report);
-            }
+            if (r.hasIssues()) out.put("BusyWaitDetector", "\n" + r);
         }
         if (atomicity != null) {
             AtomicityValidator.AtomicityReport r = atomicity.analyzeAtomicity();
-            if (r.hasIssues()) {
-                String report = "\n" + r;
-                System.err.println(report);
-                AsyncTestListenerRegistry.fireDetectorReport("AtomicityValidator", report);
-            }
+            if (r.hasIssues()) out.put("AtomicityValidator", "\n" + r);
         }
         if (interrupt != null) {
             InterruptMonitor.InterruptReport r = interrupt.analyzeInterruptHandling();
-            if (r.hasIssues()) {
-                String report = "\n" + r;
-                System.err.println(report);
-                AsyncTestListenerRegistry.fireDetectorReport("InterruptMonitor", report);
-            }
+            if (r.hasIssues()) out.put("InterruptMonitor", "\n" + r);
         }
+        return out;
     }
 }

--- a/src/main/java/se/deversity/asynctest/extension/AsyncTestExtension.java
+++ b/src/main/java/se/deversity/asynctest/extension/AsyncTestExtension.java
@@ -3,12 +3,14 @@ package se.deversity.asynctest.extension;
 import se.deversity.asynctest.AsyncTest;
 import se.deversity.vibetags.annotations.AIContract;
 import se.deversity.vibetags.annotations.AIPublicAPI;
+import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 
 import java.util.Collections;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -18,14 +20,13 @@ public class AsyncTestExtension implements TestTemplateInvocationContextProvider
 
     @Override
     public boolean supportsTestTemplate(ExtensionContext context) {
-        return context.getTestMethod()
-                .map(m -> m.isAnnotationPresent(AsyncTest.class))
-                .orElse(false);
+        return resolveAnnotation(context).isPresent();
     }
 
     @Override
     public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
-        AsyncTest asyncTest = context.getTestMethod().get().getAnnotation(AsyncTest.class);
+        AsyncTest asyncTest = resolveAnnotation(context).orElseThrow(
+            () -> new IllegalStateException("No @AsyncTest annotation found on test method or class"));
         int[] matrix = asyncTest.threadCounts();
 
         if (matrix.length == 0) {
@@ -36,6 +37,29 @@ public class AsyncTestExtension implements TestTemplateInvocationContextProvider
         // Schedule-matrix path: one invocation context per threadCounts entry.
         return IntStream.of(matrix)
                 .mapToObj(threadCount -> buildContext(asyncTest, threadCount));
+    }
+
+    /**
+     * Resolves the effective {@link AsyncTest} annotation for a test method.
+     *
+     * <p>Lookup order:
+     * <ol>
+     *   <li>the test method itself, including meta-annotations — this is what makes
+     *       composed annotations like {@code @EssentialsAsyncTest} work;</li>
+     *   <li>the test class (also meta-aware), so a class-level {@code @AsyncTest}
+     *       provides shared configuration for every {@code @TestTemplate} method.</li>
+     * </ol>
+     *
+     * @since 1.7.0
+     */
+    private static Optional<AsyncTest> resolveAnnotation(ExtensionContext context) {
+        Optional<AsyncTest> onMethod = context.getTestMethod()
+                .flatMap(m -> AnnotationSupport.findAnnotation(m, AsyncTest.class));
+        if (onMethod.isPresent()) {
+            return onMethod;
+        }
+        return context.getTestClass()
+                .flatMap(c -> AnnotationSupport.findAnnotation(c, AsyncTest.class));
     }
 
     private static TestTemplateInvocationContext buildContext(AsyncTest asyncTest, int threadCount) {

--- a/src/main/java/se/deversity/asynctest/report/Baseline.java
+++ b/src/main/java/se/deversity/asynctest/report/Baseline.java
@@ -1,0 +1,181 @@
+package se.deversity.asynctest.report;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Known-findings baseline for adopting async-test on a legacy codebase.
+ *
+ * <p>A baseline file lists detector findings that are accepted for now; matching
+ * findings are suppressed from the {@code @AsyncTest(failOn = ...)} gate instead
+ * of failing the build, letting teams enable fail-gating immediately and ratchet
+ * the baseline down over time.
+ *
+ * <p><b>File format</b> — one entry per line, diff-friendly and hand-editable:
+ * <pre>
+ * # comments and blank lines are ignored
+ * com.example.CartServiceTest#addItem_concurrently | RaceConditionDetector
+ * com.example.CartServiceTest#addItem_concurrently | SharedCollectionDetector
+ * </pre>
+ *
+ * <p><b>System properties</b>:
+ * <ul>
+ *   <li>{@code -Dasync-test.baseline=<path>} — baseline file to apply (no default).</li>
+ *   <li>{@code -Dasync-test.baseline.update=true} — instead of failing, append the
+ *       findings that would have failed to the baseline file.</li>
+ * </ul>
+ *
+ * @since 1.7.0
+ */
+public final class Baseline {
+
+    private static final Logger log = LoggerFactory.getLogger(Baseline.class);
+
+    /** System property naming the baseline file to apply. */
+    public static final String PATH_PROPERTY = "async-test.baseline";
+
+    /** System property enabling update (record) mode. */
+    public static final String UPDATE_PROPERTY = "async-test.baseline.update";
+
+    private static final Baseline EMPTY = new Baseline(Set.of());
+
+    /** Cache keyed by path; entries invalidated by last-modified time. */
+    private static final ConcurrentMap<Path, CachedBaseline> CACHE = new ConcurrentHashMap<>();
+
+    /** Guards read-merge-write cycles in {@link #record}. */
+    private static final Object WRITE_LOCK = new Object();
+
+    private final Set<String> entries;
+
+    private Baseline(Set<String> entries) {
+        this.entries = entries;
+    }
+
+    /**
+     * Resolves the active baseline from {@value #PATH_PROPERTY}; returns an empty
+     * baseline when the property is unset. A missing file is treated as empty in
+     * update mode (it will be created) and logged once otherwise.
+     */
+    public static Baseline fromSystemProperties() {
+        String prop = System.getProperty(PATH_PROPERTY);
+        if (prop == null || prop.isBlank()) {
+            return EMPTY;
+        }
+        return load(Path.of(prop));
+    }
+
+    /** Whether {@value #UPDATE_PROPERTY} is set, switching the gate to record mode. */
+    public static boolean updateMode() {
+        return Boolean.getBoolean(UPDATE_PROPERTY);
+    }
+
+    /** Loads (with caching by last-modified time) the baseline at {@code path}. */
+    public static Baseline load(Path path) {
+        if (!Files.exists(path)) {
+            if (!updateMode()) {
+                log.warn("[AsyncTest] Baseline file not found: {} — no findings will be suppressed", path);
+            }
+            return new Baseline(Set.of());
+        }
+        try {
+            long lastModified = Files.getLastModifiedTime(path).toMillis();
+            CachedBaseline cached = CACHE.get(path);
+            if (cached != null && cached.lastModified == lastModified) {
+                return cached.baseline;
+            }
+            Set<String> entries = new TreeSet<>();
+            for (String line : Files.readAllLines(path, StandardCharsets.UTF_8)) {
+                String trimmed = line.trim();
+                if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                    continue;
+                }
+                entries.add(normalize(trimmed));
+            }
+            Baseline loaded = new Baseline(Set.copyOf(entries));
+            CACHE.put(path, new CachedBaseline(lastModified, loaded));
+            return loaded;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read baseline file: " + path, e);
+        }
+    }
+
+    /** Returns {@code true} when the (test, detector) finding is baselined. */
+    public boolean contains(String testId, String detectorName) {
+        return entries.contains(key(testId, detectorName));
+    }
+
+    /** Number of entries in this baseline. */
+    public int size() {
+        return entries.size();
+    }
+
+    /**
+     * Appends the given (test, detector) findings to the baseline file named by
+     * {@value #PATH_PROPERTY}, creating it if needed and skipping entries already
+     * present. Thread-safe across concurrently-running tests in the same JVM.
+     *
+     * @return the number of entries actually added
+     */
+    public static int record(String testId, Collection<String> detectorNames) {
+        String prop = System.getProperty(PATH_PROPERTY);
+        if (prop == null || prop.isBlank()) {
+            log.warn("[AsyncTest] {} set but {} is not — nothing recorded", UPDATE_PROPERTY, PATH_PROPERTY);
+            return 0;
+        }
+        Path path = Path.of(prop);
+        synchronized (WRITE_LOCK) {
+            try {
+                Set<String> merged = new TreeSet<>();
+                if (Files.exists(path)) {
+                    merged.addAll(load(path).entries);
+                }
+                int before = merged.size();
+                for (String detector : detectorNames) {
+                    merged.add(key(testId, detector));
+                }
+                int added = merged.size() - before;
+                if (added > 0) {
+                    Path parent = path.getParent();
+                    if (parent != null) {
+                        Files.createDirectories(parent);
+                    }
+                    List<String> lines = new java.util.ArrayList<>();
+                    lines.add("# async-test baseline — accepted findings; remove lines as they are fixed");
+                    lines.add("# format: <testClass>#<testMethod> | <DetectorName>");
+                    lines.addAll(merged);
+                    Files.write(path, lines, StandardCharsets.UTF_8);
+                    CACHE.remove(path); // next load() re-reads the merged file
+                }
+                return added;
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to update baseline file: " + path, e);
+            }
+        }
+    }
+
+    private static String key(String testId, String detectorName) {
+        return normalize(testId + " | " + detectorName);
+    }
+
+    private static String normalize(String line) {
+        int sep = line.indexOf('|');
+        if (sep < 0) {
+            return line.trim();
+        }
+        return line.substring(0, sep).trim() + " | " + line.substring(sep + 1).trim();
+    }
+
+    private record CachedBaseline(long lastModified, Baseline baseline) {}
+}

--- a/src/main/java/se/deversity/asynctest/runner/ConcurrencyRunner.java
+++ b/src/main/java/se/deversity/asynctest/runner/ConcurrencyRunner.java
@@ -13,15 +13,19 @@ import se.deversity.asynctest.AsyncTestListenerRegistry;
 import se.deversity.asynctest.BeforeEachInvocation;
 import se.deversity.asynctest.benchmark.BenchmarkRecorder;
 import se.deversity.asynctest.diagnostics.DeadlockDetector;
+import se.deversity.asynctest.diagnostics.IssueSeverity;
 import se.deversity.asynctest.diagnostics.MemoryModelValidator;
 import se.deversity.asynctest.diagnostics.Phase1DetectorSet;
 import se.deversity.asynctest.diagnostics.VirtualThreadStressConfig;
+import se.deversity.asynctest.report.Baseline;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -194,6 +198,74 @@ public class ConcurrencyRunner {
                 }
             }
         }
+
+        // Success path only (the catch blocks above rethrow): analyze detectors,
+        // surface findings to stderr and listeners, and apply the failOn gate.
+        // Runs on the caller thread after all workers finished and the executor
+        // shut down — no shared mutable state is touched concurrently.
+        analyzeAndGate(config, testMethod, phase1, phase2Context);
+    }
+
+    /**
+     * Post-run detector analysis for tests whose body passed.
+     *
+     * <p>Before 1.7.0 detector findings were only reported when the test body had
+     * already failed or timed out; a passing test never surfaced findings. This
+     * method closes that gap: every enabled detector is analyzed, findings are
+     * printed and fired to listeners, and findings at or above
+     * {@link AsyncTestConfig#failOn} fail the test — unless suppressed by the
+     * baseline file ({@code -Dasync-test.baseline=<path>}) or recorded to it in
+     * update mode ({@code -Dasync-test.baseline.update=true}).
+     */
+    private static void analyzeAndGate(AsyncTestConfig config,
+                                       Method testMethod,
+                                       Phase1DetectorSet phase1,
+                                       AsyncTestContext phase2Context) {
+        Map<String, String> reports = new LinkedHashMap<>(phase1.collectReports());
+        for (String report : phase2Context.analyzeAll()) {
+            reports.putIfAbsent(extractDetectorName(report), "\n" + report);
+        }
+        if (reports.isEmpty()) {
+            return;
+        }
+
+        String testId = testMethod.getDeclaringClass().getName() + "#" + testMethod.getName();
+        Baseline baseline = Baseline.fromSystemProperties();
+
+        int suppressed = 0;
+        List<String> failing = new ArrayList<>();
+        for (Map.Entry<String, String> e : reports.entrySet()) {
+            if (baseline.contains(testId, e.getKey())) {
+                suppressed++;
+                continue;
+            }
+            System.err.println(e.getValue());
+            AsyncTestListenerRegistry.fireDetectorReport(e.getKey(), e.getValue());
+            if (config.failOn.triggeredBy(IssueSeverity.fromReport(e.getValue()))) {
+                failing.add(e.getKey());
+            }
+        }
+        if (suppressed > 0) {
+            log.info("[AsyncTest] {} baselined finding(s) suppressed for {}", suppressed, testId);
+        }
+        if (failing.isEmpty()) {
+            return;
+        }
+
+        if (Baseline.updateMode()) {
+            int added = Baseline.record(testId, failing);
+            log.warn("[AsyncTest] Baseline update mode: recorded {} finding(s) for {} instead of failing",
+                    added, testId);
+            return;
+        }
+
+        AssertionError error = new AssertionError(
+            "[AsyncTest] " + failing.size() + " detector finding(s) at or above failOn=" + config.failOn
+            + " for " + testId + ": " + String.join(", ", failing)
+            + ". Full reports above. To accept known findings, run with -D" + Baseline.PATH_PROPERTY
+            + "=<file> (add -D" + Baseline.UPDATE_PROPERTY + "=true once to record them).");
+        AsyncTestListenerRegistry.fireTestFailed(error);
+        throw error;
     }
 
     /**

--- a/src/test/java/se/deversity/asynctest/IncludesConfigTest.java
+++ b/src/test/java/se/deversity/asynctest/IncludesConfigTest.java
@@ -1,0 +1,95 @@
+package se.deversity.asynctest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies {@code @AsyncTest(includes = {...})} and {@code Builder.includes(...)}:
+ * only the listed detectors are enabled, excludes win on conflict, and a
+ * non-empty includes overrides preset/detectAll.
+ */
+class IncludesConfigTest {
+
+    private static AsyncTest annotationOf(String methodName) throws NoSuchMethodException {
+        return Holder.class.getDeclaredMethod(methodName).getAnnotation(AsyncTest.class);
+    }
+
+    @Test
+    void includesEnablesExactlyTheListedDetectors() throws Exception {
+        AsyncTestConfig cfg = AsyncTestConfig.from(annotationOf("includesTwo"));
+
+        assertTrue(cfg.detectDeadlocks, "included detector must be enabled");
+        assertTrue(cfg.detectSharedMessageDigest, "included detector must be enabled");
+        assertFalse(cfg.detectRaceConditions, "non-included detector must be disabled");
+        assertFalse(cfg.detectSharedCollections, "non-included detector must be disabled");
+        assertFalse(cfg.detectVisibility, "non-included detector must be disabled");
+    }
+
+    @Test
+    void includesOverridesDetectAllFalse() throws Exception {
+        AsyncTestConfig cfg = AsyncTestConfig.from(annotationOf("includesDespiteDetectAllFalse"));
+
+        assertTrue(cfg.detectSharedMessageDigest,
+            "includes must win over detectAll=false");
+        assertFalse(cfg.detectRaceConditions);
+    }
+
+    @Test
+    void includesOverridesPreset() throws Exception {
+        AsyncTestConfig cfg = AsyncTestConfig.from(annotationOf("includesDespitePresetNone"));
+
+        assertTrue(cfg.detectDeadlocks, "includes must win over preset=NONE");
+        assertFalse(cfg.detectSharedMessageDigest);
+    }
+
+    @Test
+    void excludesWinsOverIncludes() throws Exception {
+        AsyncTestConfig cfg = AsyncTestConfig.from(annotationOf("includeAndExcludeSame"));
+
+        assertFalse(cfg.detectDeadlocks, "excludes must win on conflict with includes");
+        assertTrue(cfg.detectSharedMessageDigest, "non-conflicting include stays enabled");
+    }
+
+    @Test
+    void emptyIncludesKeepsLegacyDetectAllSemantics() throws Exception {
+        AsyncTestConfig cfg = AsyncTestConfig.from(annotationOf("plainDetectAll"));
+
+        assertTrue(cfg.detectDeadlocks);
+        assertTrue(cfg.detectRaceConditions);
+        assertTrue(cfg.detectSharedMessageDigest);
+    }
+
+    @Test
+    void builderIncludesMirrorsAnnotationSemantics() {
+        AsyncTestConfig cfg = AsyncTestConfig.builder()
+            .includes(new DetectorType[] {DetectorType.DEADLOCKS, DetectorType.SHARED_MESSAGE_DIGEST})
+            .excludes(new DetectorType[] {DetectorType.SHARED_MESSAGE_DIGEST})
+            .build();
+
+        assertTrue(cfg.detectDeadlocks);
+        assertFalse(cfg.detectSharedMessageDigest, "builder excludes must win over includes");
+        assertFalse(cfg.detectRaceConditions);
+    }
+
+    @SuppressWarnings("unused")
+    static class Holder {
+
+        @AsyncTest(includes = {DetectorType.DEADLOCKS, DetectorType.SHARED_MESSAGE_DIGEST})
+        void includesTwo() {}
+
+        @AsyncTest(detectAll = false, includes = {DetectorType.SHARED_MESSAGE_DIGEST})
+        void includesDespiteDetectAllFalse() {}
+
+        @AsyncTest(preset = Preset.NONE, includes = {DetectorType.DEADLOCKS})
+        void includesDespitePresetNone() {}
+
+        @AsyncTest(includes = {DetectorType.DEADLOCKS, DetectorType.SHARED_MESSAGE_DIGEST},
+                   excludes = {DetectorType.DEADLOCKS})
+        void includeAndExcludeSame() {}
+
+        @AsyncTest(detectAll = true)
+        void plainDetectAll() {}
+    }
+}

--- a/src/test/java/se/deversity/asynctest/PresetResolutionTest.java
+++ b/src/test/java/se/deversity/asynctest/PresetResolutionTest.java
@@ -135,6 +135,8 @@ class PresetResolutionTest {
         @Override public Preset preset() { return preset; }
         @Override public long replaySeed() { return def("replaySeed"); }
         @Override public DetectorType[] excludes() { return excludes; }
+        @Override public DetectorType[] includes() { return def("includes"); }
+        @Override public FailOn failOn() { return def("failOn"); }
         @Override public boolean detectFalseSharing() { return def("detectFalseSharing"); }
         @Override public boolean detectWakeupIssues() { return def("detectWakeupIssues"); }
         @Override public boolean validateConstructorSafety() { return def("validateConstructorSafety"); }

--- a/src/test/java/se/deversity/asynctest/extension/ClassLevelAsyncTestTest.java
+++ b/src/test/java/se/deversity/asynctest/extension/ClassLevelAsyncTestTest.java
@@ -1,0 +1,100 @@
+package se.deversity.asynctest.extension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+import se.deversity.asynctest.AsyncTest;
+import se.deversity.asynctest.Preset;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies the 1.7.0 annotation-placement extensions:
+ * <ul>
+ *   <li>class-level {@code @AsyncTest} configures {@code @TestTemplate} methods,</li>
+ *   <li>composed (meta-)annotations carry {@code @AsyncTest} configuration,</li>
+ *   <li>a method-level {@code @AsyncTest} wins over the class-level one.</li>
+ * </ul>
+ */
+class ClassLevelAsyncTestTest {
+
+    @Test
+    void classLevelAnnotationDrivesTestTemplateMethods() {
+        Events tests = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(ClassLevelFixture.class))
+                .execute()
+                .testEvents();
+
+        tests.assertStatistics(s -> s.started(2).succeeded(2).failed(0));
+    }
+
+    @Test
+    void composedAnnotationCarriesAsyncTestConfiguration() {
+        Events tests = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(ComposedAnnotationFixture.class))
+                .execute()
+                .testEvents();
+
+        tests.assertStatistics(s -> s.started(1).succeeded(1).failed(0));
+
+        String name = tests.finished().stream()
+                .map(e -> e.getTestDescriptor().getDisplayName())
+                .findFirst().orElseThrow();
+        assertEquals("[AsyncTest] 3 threads x 1 invocations", name,
+                "Composed annotation's @AsyncTest attributes must drive the run");
+    }
+
+    @Test
+    void methodLevelAnnotationWinsOverClassLevel() {
+        Events tests = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(PrecedenceFixture.class))
+                .execute()
+                .testEvents();
+
+        tests.assertStatistics(s -> s.started(1).succeeded(1).failed(0));
+
+        String name = tests.finished().stream()
+                .map(e -> e.getTestDescriptor().getDisplayName())
+                .findFirst().orElseThrow();
+        assertEquals("[AsyncTest] 5 threads x 1 invocations", name,
+                "Method-level @AsyncTest must take precedence over the class-level one");
+    }
+
+    // ---- Fixtures driven through JUnit-platform-testkit ----
+
+    @AsyncTest(threads = 2, invocations = 1, timeoutMs = 10_000,
+            preset = Preset.NONE, licenseMockMode = true)
+    static class ClassLevelFixture {
+        @TestTemplate
+        void first() {}
+
+        @TestTemplate
+        void second() {}
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @AsyncTest(threads = 3, invocations = 1, timeoutMs = 10_000,
+            preset = Preset.NONE, licenseMockMode = true)
+    @interface QuickAsyncTest {}
+
+    static class ComposedAnnotationFixture {
+        @QuickAsyncTest
+        void composed() {}
+    }
+
+    @AsyncTest(threads = 2, invocations = 1, timeoutMs = 10_000,
+            preset = Preset.NONE, licenseMockMode = true)
+    static class PrecedenceFixture {
+        @AsyncTest(threads = 5, invocations = 1, timeoutMs = 10_000,
+                preset = Preset.NONE, licenseMockMode = true)
+        void methodWins() {}
+    }
+}

--- a/src/test/java/se/deversity/asynctest/report/BaselineTest.java
+++ b/src/test/java/se/deversity/asynctest/report/BaselineTest.java
@@ -1,0 +1,135 @@
+package se.deversity.asynctest.report;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+import se.deversity.asynctest.AsyncTest;
+import se.deversity.asynctest.AsyncTestContext;
+import se.deversity.asynctest.DetectorType;
+import se.deversity.asynctest.FailOn;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the known-findings baseline: file parsing, matching, update mode,
+ * and end-to-end suppression of the {@code failOn} gate.
+ */
+class BaselineTest {
+
+    @TempDir
+    Path tempDir;
+
+    @AfterEach
+    void clearSystemProperties() {
+        System.clearProperty(Baseline.PATH_PROPERTY);
+        System.clearProperty(Baseline.UPDATE_PROPERTY);
+    }
+
+    // ---- Unit: parsing & matching ----
+
+    @Test
+    void parsesEntriesAndIgnoresCommentsAndBlanks() throws Exception {
+        Path file = tempDir.resolve("baseline.txt");
+        Files.write(file, List.of(
+                "# a comment",
+                "",
+                "com.example.FooTest#bar | RaceConditionDetector",
+                "  com.example.FooTest#baz   |   SharedCollectionDetector  "
+        ), StandardCharsets.UTF_8);
+
+        Baseline baseline = Baseline.load(file);
+
+        assertEquals(2, baseline.size());
+        assertTrue(baseline.contains("com.example.FooTest#bar", "RaceConditionDetector"));
+        assertTrue(baseline.contains("com.example.FooTest#baz", "SharedCollectionDetector"),
+                "whitespace around separators must be tolerated");
+        assertFalse(baseline.contains("com.example.FooTest#bar", "SharedCollectionDetector"));
+    }
+
+    @Test
+    void missingFileYieldsEmptyBaseline() {
+        Baseline baseline = Baseline.load(tempDir.resolve("does-not-exist.txt"));
+        assertEquals(0, baseline.size());
+        assertFalse(baseline.contains("x#y", "Anything"));
+    }
+
+    @Test
+    void recordAppendsAndDeduplicates() throws Exception {
+        Path file = tempDir.resolve("baseline.txt");
+        System.setProperty(Baseline.PATH_PROPERTY, file.toString());
+
+        assertEquals(2, Baseline.record("com.example.FooTest#bar",
+                List.of("RaceConditionDetector", "SharedCollectionDetector")));
+        assertEquals(0, Baseline.record("com.example.FooTest#bar",
+                List.of("RaceConditionDetector")), "duplicate entries must not be re-added");
+        assertEquals(1, Baseline.record("com.example.FooTest#other",
+                List.of("RaceConditionDetector")));
+
+        Baseline reloaded = Baseline.load(file);
+        assertEquals(3, reloaded.size());
+        assertTrue(reloaded.contains("com.example.FooTest#other", "RaceConditionDetector"));
+    }
+
+    // ---- Integration: baseline suppresses the failOn gate ----
+
+    @Test
+    void updateModeRecordsFindingsInsteadOfFailing_thenBaselineSuppressesThem() throws Exception {
+        Path file = tempDir.resolve("baseline.txt");
+        System.setProperty(Baseline.PATH_PROPERTY, file.toString());
+
+        // 1. Without a baseline entry and without update mode, the gate fails the test.
+        Events failing = runFixture();
+        failing.assertStatistics(s -> s.failed(1));
+
+        // 2. Update mode: same run passes and records the finding.
+        System.setProperty(Baseline.UPDATE_PROPERTY, "true");
+        Events recording = runFixture();
+        recording.assertStatistics(s -> s.succeeded(1).failed(0));
+        assertTrue(Files.exists(file), "update mode must create the baseline file");
+        assertTrue(Baseline.load(file).size() > 0, "update mode must record the finding");
+
+        // 3. Update mode off again: the recorded baseline suppresses the finding.
+        System.clearProperty(Baseline.UPDATE_PROPERTY);
+        Events suppressed = runFixture();
+        suppressed.assertStatistics(s -> s.succeeded(1).failed(0));
+    }
+
+    private static Events runFixture() {
+        return EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(BaselinedFixture.class))
+                .execute()
+                .testEvents();
+    }
+
+    private static MessageDigest sharedDigest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    static class BaselinedFixture {
+        private final MessageDigest shared = sharedDigest();
+
+        @AsyncTest(threads = 2, invocations = 2, timeoutMs = 10_000,
+                includes = {DetectorType.SHARED_MESSAGE_DIGEST},
+                failOn = FailOn.HIGH, licenseMockMode = true)
+        void sharedDigestAcrossThreads() {
+            AsyncTestContext.sharedMessageDigestDetector()
+                    .recordAccess(shared, "shared-sha256", Thread.currentThread());
+        }
+    }
+}

--- a/src/test/java/se/deversity/asynctest/runner/FailOnGateTest.java
+++ b/src/test/java/se/deversity/asynctest/runner/FailOnGateTest.java
@@ -1,0 +1,130 @@
+package se.deversity.asynctest.runner;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+import se.deversity.asynctest.AsyncTest;
+import se.deversity.asynctest.AsyncTestContext;
+import se.deversity.asynctest.DetectorType;
+import se.deversity.asynctest.FailOn;
+import se.deversity.asynctest.diagnostics.IssueSeverity;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the {@code @AsyncTest(failOn = ...)} severity gate:
+ * <ul>
+ *   <li>{@link FailOn#triggeredBy} threshold mapping,</li>
+ *   <li>a passing test body fails when a detector finding meets the threshold,</li>
+ *   <li>the default {@link FailOn#NONE} keeps the legacy report-only behavior.</li>
+ * </ul>
+ *
+ * <p>The fixtures deterministically trigger {@code SharedMessageDigestDetector}
+ * (severity HIGH) by recording the same {@link MessageDigest} instance from
+ * every worker thread — also exercising {@code includes = {...}} end-to-end.
+ */
+class FailOnGateTest {
+
+    @Test
+    void triggeredByMatchesThresholdSemantics() {
+        assertFalse(FailOn.NONE.triggeredBy(IssueSeverity.CRITICAL));
+        assertFalse(FailOn.NONE.triggeredBy(IssueSeverity.LOW));
+
+        assertTrue(FailOn.LOW.triggeredBy(IssueSeverity.LOW));
+        assertTrue(FailOn.LOW.triggeredBy(IssueSeverity.CRITICAL));
+
+        assertFalse(FailOn.MEDIUM.triggeredBy(IssueSeverity.LOW));
+        assertTrue(FailOn.MEDIUM.triggeredBy(IssueSeverity.MEDIUM));
+
+        assertFalse(FailOn.HIGH.triggeredBy(IssueSeverity.MEDIUM));
+        assertTrue(FailOn.HIGH.triggeredBy(IssueSeverity.HIGH));
+        assertTrue(FailOn.HIGH.triggeredBy(IssueSeverity.CRITICAL));
+
+        assertFalse(FailOn.CRITICAL.triggeredBy(IssueSeverity.HIGH));
+        assertTrue(FailOn.CRITICAL.triggeredBy(IssueSeverity.CRITICAL));
+
+        assertFalse(FailOn.LOW.triggeredBy(null));
+    }
+
+    @Test
+    void findingAtThresholdFailsThePassingTest() {
+        Events tests = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(FailOnHighFixture.class))
+                .execute()
+                .testEvents();
+
+        tests.assertStatistics(s -> s.started(1).succeeded(0).failed(1));
+    }
+
+    @Test
+    void defaultFailOnNoneKeepsReportOnlyBehavior() {
+        Events tests = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(ReportOnlyFixture.class))
+                .execute()
+                .testEvents();
+
+        tests.assertStatistics(s -> s.started(1).succeeded(1).failed(0));
+    }
+
+    @Test
+    void findingBelowThresholdDoesNotFail() {
+        Events tests = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(FailOnCriticalFixture.class))
+                .execute()
+                .testEvents();
+
+        // SharedMessageDigest findings are HIGH — below the CRITICAL threshold.
+        tests.assertStatistics(s -> s.started(1).succeeded(1).failed(0));
+    }
+
+    // ---- Fixtures driven through JUnit-platform-testkit ----
+
+    private static MessageDigest sharedDigest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    static class FailOnHighFixture {
+        private final MessageDigest shared = sharedDigest();
+
+        @AsyncTest(threads = 2, invocations = 2, timeoutMs = 10_000,
+                includes = {DetectorType.SHARED_MESSAGE_DIGEST},
+                failOn = FailOn.HIGH, licenseMockMode = true)
+        void sharedDigestAcrossThreads() {
+            AsyncTestContext.sharedMessageDigestDetector()
+                    .recordAccess(shared, "shared-sha256", Thread.currentThread());
+        }
+    }
+
+    static class ReportOnlyFixture {
+        private final MessageDigest shared = sharedDigest();
+
+        @AsyncTest(threads = 2, invocations = 2, timeoutMs = 10_000,
+                includes = {DetectorType.SHARED_MESSAGE_DIGEST},
+                licenseMockMode = true)
+        void sharedDigestAcrossThreads() {
+            AsyncTestContext.sharedMessageDigestDetector()
+                    .recordAccess(shared, "shared-sha256", Thread.currentThread());
+        }
+    }
+
+    static class FailOnCriticalFixture {
+        private final MessageDigest shared = sharedDigest();
+
+        @AsyncTest(threads = 2, invocations = 2, timeoutMs = 10_000,
+                includes = {DetectorType.SHARED_MESSAGE_DIGEST},
+                failOn = FailOn.CRITICAL, licenseMockMode = true)
+        void sharedDigestAcrossThreads() {
+            AsyncTestContext.sharedMessageDigestDetector()
+                    .recordAccess(shared, "shared-sha256", Thread.currentThread());
+        }
+    }
+}


### PR DESCRIPTION
…seline

Four additions to detector selection and CI fail-gating:

- @AsyncTest(includes = {DetectorType...}): enable exactly the listed detectors. Wins over preset/detectAll/per-detector booleans; excludes still layers on top. Resolved in AsyncTestConfig.from() the same way presets are (complement -> excludes), plus Builder.includes() parity.

- Class-level and composed @AsyncTest: @Target gains TYPE and ANNOTATION_TYPE; AsyncTestExtension resolves the annotation meta-aware (method first, then class) via AnnotationSupport.findAnnotation, so a class-level @AsyncTest configures @TestTemplate methods and users can compose reusable annotations (e.g. @EssentialsAsyncTest).

- @AsyncTest(failOn = FailOn.X): severity gate on detector findings. ConcurrencyRunner now analyzes detectors on the success path too (previously findings only surfaced when the body had already failed), prints reports, fires listeners, and throws when a finding meets the threshold. Default FailOn.NONE preserves report-only behavior. The gate runs on the caller thread after all workers complete, preserving the runner's thread-safety and cleanup invariants.

- Known-findings baseline (report.Baseline): -Dasync-test.baseline=<file>
  suppresses baselined findings from the gate; -Dasync-test.baseline.update records them instead of failing. Line format: "test#method | DetectorName".