### PR TITLE
feat: JDK 25/26 standalone async detectors (StableValue, StructuredTaskScope, Gatherer) + full docs

### DIFF
--- a/.claude/SKILL.md
+++ b/.claude/SKILL.md
@@ -1,6 +1,6 @@
 # async-test-lib — Usage Guide
 
-**async-test-lib** is a JUnit 5 extension for stress-testing concurrent Java code. It forces real thread collisions using a `CyclicBarrier`, then runs 111 specialized detectors across 14 phases to identify exactly what went wrong.
+**async-test-lib** is a JUnit 5 extension for stress-testing concurrent Java code. It forces real thread collisions using a `CyclicBarrier`, then runs 111 specialized detectors across 14 phases to identify exactly what went wrong — plus three standalone JDK 25/26 detectors (`StableValue`, `StructuredTaskScope`, parallel `Gatherer`) you can drive directly.
 
 - Replaces `@Test` with `@AsyncTest` — zero other changes needed
 - Requires Java 21 and JUnit 5 (Jupiter 6.0.3+)
@@ -454,6 +454,44 @@ All detector flags below default to `true` and are gated by `detectAll`. Set `de
 | `detectSharedDeflater` | `SHARED_DEFLATER` | `java.util.zip.Deflater`/`Inflater` accessed from multiple threads. Both wrap a stateful native zlib stream and are not thread-safe; concurrent use corrupts output or crashes when one thread calls `end()` mid-stream. Instrument via `recordAccess(deflater/inflater, name, thread)`. |
 | `detectThisEscape` | `THIS_ESCAPE` | A constructor that publishes `this` before returning (starts a thread, registers a listener, stores into shared state), exposing a partially-constructed object — no final-field visibility guarantee, fields may still be default. Instrument via `recordConstructorEscape(this, how, thread)`, plus optional `recordExternalAccess(instance, thread)` / `recordConstructionComplete(instance)`. MEDIUM, escalated to HIGH when another thread observes it before completion. |
 | `detectThreadLocalRandomMisuse` | `THREAD_LOCAL_RANDOM_MISUSE` | A `ThreadLocalRandom.current()` reference cached (e.g. in a field) and used from a thread other than the one that obtained it, defeating its per-thread isolation. Instrument via `recordObtain(rng, name, thread)` then `recordUse(rng, thread)`. Distinct from `SHARED_RANDOM` (`java.util.Random`) and `SHARED_SECURE_RANDOM`. |
+
+### JDK 25/26 preview-era detectors — standalone (1.7.0+)
+
+These three detectors target concurrency features introduced/finalized in JDK 24–26.
+They are **not** wired into the `@AsyncTest` `detectAll` pipeline (a pipeline detector
+needs a `DetectorType` enum constant, and that enum is a locked file). Use them
+**directly**: instantiate, record events from your test body, then call `analyze()`
+and assert on the report. They live in `se.deversity.asynctest.diagnostics` and are
+thread-safe (`ConcurrentHashMap`-backed), so a single instance can be shared across
+the worker threads of an `@AsyncTest`.
+
+| Detector | JDK feature | Record API | What it catches |
+|----------|-------------|------------|-----------------|
+| `StableValueMisuseDetector` | `StableValue` — JEP 502 (preview JDK 25 → 26) | `recordSet(name, thread)`, `recordRead(name, thread)`, `recordSupplierStart/End(name, thread)` | read-before-set (`NoSuchElementException`), double-set (lost update / `IllegalStateException`), reentrant `orElseSet` supplier, set-contention |
+| `StructuredTaskScopeMisuseDetector` | `StructuredTaskScope` — JEP 505 (preview JDK 25 → final JDK 26) | `recordScopeOpened(id, owner)`, `recordFork(id, subtaskId, thread)`, `recordJoin(id, thread)`, `recordResultRead(id, subtaskId, thread)`, `recordScopeClosed(id, thread)` | fork-after-join, `Subtask.get()` before join, owner-confinement (`WrongThreadException`), close-without-join (subtasks cancelled) |
+| `GathererConcurrencyMisuseDetector` | Stream Gatherers — JEP 485 (final JDK 24) | `registerGatherer(name, hasCombiner, parallel)`, `recordIntegrate(name, thread)` | stateful gatherer on a parallel stream with no combiner (lost results), concurrent-integrator shared-state race |
+
+```java
+import se.deversity.asynctest.diagnostics.StableValueMisuseDetector;
+
+@AsyncTest(threads = 16, invocations = 50, detectAll = false)  // drive the contention
+void stableValueLazyInit() {
+    detector.recordSupplierStart("CONFIG", Thread.currentThread());
+    Config c = configHolderUnderTest();           // models StableValue.orElseSet(...)
+    detector.recordSupplierEnd("CONFIG", Thread.currentThread());
+    detector.recordRead("CONFIG", Thread.currentThread());
+}
+
+@AfterEach
+void assertNoMisuse() {
+    var report = detector.analyze();
+    assertFalse(report.hasIssues(), report::toString);   // shared field: private final ...Detector detector = new ...();
+}
+```
+
+Each `analyze()` returns a typed `*Report` with `hasIssues()`, per-category issue
+lists, and a `toString()` that includes a `📚 LEARNING` block — same shape as every
+other detector report.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,11 @@
       <frameworks>JUNIT_5</frameworks>
       <test_location>src/test/java/se/deversity/asynctest/diagnostics/FutureIgnoredDetectorTest.java</test_location>
     </element>
+    <element path="se.deversity.asynctest.diagnostics.GathererConcurrencyMisuseDetector">
+      <coverage_goal>80</coverage_goal>
+      <frameworks>JUNIT_5</frameworks>
+      <test_location>src/test/java/se/deversity/asynctest/diagnostics/GathererConcurrencyMisuseDetectorTest.java</test_location>
+    </element>
     <element path="se.deversity.asynctest.diagnostics.HttpClientConcurrencyDetector">
       <coverage_goal>80</coverage_goal>
       <frameworks>JUNIT_5</frameworks>
@@ -417,6 +422,11 @@
       <frameworks>JUNIT_5</frameworks>
       <test_location>src/test/java/se/deversity/asynctest/diagnostics/SpuriousWakeupDetectorTest.java</test_location>
     </element>
+    <element path="se.deversity.asynctest.diagnostics.StableValueMisuseDetector">
+      <coverage_goal>80</coverage_goal>
+      <frameworks>JUNIT_5</frameworks>
+      <test_location>src/test/java/se/deversity/asynctest/diagnostics/StableValueMisuseDetectorTest.java</test_location>
+    </element>
     <element path="se.deversity.asynctest.diagnostics.StampedLockDetector">
       <coverage_goal>80</coverage_goal>
       <frameworks>JUNIT_5</frameworks>
@@ -441,6 +451,11 @@
       <coverage_goal>80</coverage_goal>
       <frameworks>JUNIT_5</frameworks>
       <test_location>src/test/java/se/deversity/asynctest/diagnostics/StructuredConcurrencyMisuseDetectorTest.java</test_location>
+    </element>
+    <element path="se.deversity.asynctest.diagnostics.StructuredTaskScopeMisuseDetector">
+      <coverage_goal>80</coverage_goal>
+      <frameworks>JUNIT_5</frameworks>
+      <test_location>src/test/java/se/deversity/asynctest/diagnostics/StructuredTaskScopeMisuseDetectorTest.java</test_location>
     </element>
     <element path="se.deversity.asynctest.diagnostics.SynchronizedCollectionIterationDetector">
       <coverage_goal>80</coverage_goal>

--- a/README.md
+++ b/README.md
@@ -154,8 +154,18 @@ After the run, the **detector registry** analyses what was observed and reports 
 | **Environment** | Uncommitted Git changes (reproducibility gate) |
 | **Phase 13** | Daemon-thread hygiene, illegal `notify*()`, shared `SecureRandom`, shared `WeakHashMap`/`IdentityHashMap`, shared JDBC `Connection`/`Statement`/`ResultSet` |
 | **Phase 14** (new) | Shared stateful crypto (`Cipher`/`Mac`/`Signature`), non-atomic `ConcurrentMap` check-then-act, shared `Deflater`/`Inflater`, constructor `this`-escape, cached `ThreadLocalRandom` used off-thread |
+| **JDK 25/26 preview** (new) | `StableValue` misuse (read-before-set / double-set / reentrant `orElseSet`), `StructuredTaskScope` lifecycle (fork-after-join, result-before-join, owner-confinement, missing join), parallel-`Gatherer` without a combiner |
 
 Full parameter reference: [docs/USAGE.md](docs/USAGE.md)
+
+> **JDK 25/26 detectors are standalone.** `StableValueMisuseDetector`,
+> `StructuredTaskScopeMisuseDetector`, and `GathererConcurrencyMisuseDetector`
+> ship in `se.deversity.asynctest.diagnostics` and are used directly — instantiate,
+> record events, call `analyze()`. They are **not yet wired into the `@AsyncTest`
+> `detectAll` pipeline**: each pipeline detector needs a `DetectorType` enum
+> constant, and that enum is a locked file (adding a constant requires a
+> synchronized six-place change). They are ready to wire the moment a slot opens.
+> See [docs/DETECTOR_CATALOG.md](docs/DETECTOR_CATALOG.md#jdk-2526-preview-era-detectors-standalone).
 
 ---
 

--- a/consumer-fixture/README.md
+++ b/consumer-fixture/README.md
@@ -48,3 +48,10 @@ mvn install -DskipTests && mvn -f consumer-fixture\pom.xml test
   imports.
 - `AsyncTestPublishedDependencyTest` — verifies the published POM exposes
   exactly the expected transitive dependencies.
+- `ConsumerJdk25And26DetectorsTest` — added in the 1.7.0 cycle; smoke-tests the
+  standalone JDK 25/26 detectors (`StableValueMisuseDetector`,
+  `StructuredTaskScopeMisuseDetector`, `GathererConcurrencyMisuseDetector`) through
+  their public `recordXxx` / `analyze()` API. These detectors are not wired into
+  `@AsyncTest` (no `DetectorType` constant — that enum is locked), so a consumer
+  reaches them directly; a passing run proves the classes and their report
+  accessors are part of the stable public surface.

--- a/consumer-fixture/src/test/java/se/deversity/asynctest/fixture/ConsumerJdk25And26DetectorsTest.java
+++ b/consumer-fixture/src/test/java/se/deversity/asynctest/fixture/ConsumerJdk25And26DetectorsTest.java
@@ -1,0 +1,105 @@
+package se.deversity.asynctest.fixture;
+
+import org.junit.jupiter.api.Test;
+import se.deversity.asynctest.diagnostics.GathererConcurrencyMisuseDetector;
+import se.deversity.asynctest.diagnostics.StableValueMisuseDetector;
+import se.deversity.asynctest.diagnostics.StructuredTaskScopeMisuseDetector;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Consumer-side smoke tests for the standalone JDK 25/26 detectors added in 1.7.0:
+ * {@code StableValueMisuseDetector}, {@code StructuredTaskScopeMisuseDetector}, and
+ * {@code GathererConcurrencyMisuseDetector}.
+ *
+ * <p>These compile against the published artifact (consumer-fixture depends on the deployed
+ * JAR, not the source), so a passing run proves the three detector classes — and their
+ * record/analyze API and report accessors — are part of the stable public surface a
+ * consumer can reach without depending on internal classes.
+ *
+ * <p>Unlike the pipeline detectors, these are <strong>not</strong> wired into
+ * {@code @AsyncTest} (no {@code DetectorType} constant — that enum is locked). They are used
+ * directly: instantiate, record events, call {@code analyze()}.
+ */
+class ConsumerJdk25And26DetectorsTest {
+
+    // ---- StableValueMisuseDetector (JEP 502) ----
+
+    @Test
+    void stableValue_detector_public_api_flags_read_before_set() {
+        var d = new StableValueMisuseDetector();
+        Thread t = Thread.currentThread();
+
+        d.recordRead("CONFIG", t);                 // read before any set
+        var report = d.analyze();
+        assertTrue(report.hasIssues());
+        assertFalse(report.getReadBeforeSetIssues().isEmpty());
+        assertEquals(1, report.getTotalReads());
+    }
+
+    @Test
+    void stableValue_detector_clean_when_set_then_read() {
+        var d = new StableValueMisuseDetector();
+        Thread t = Thread.currentThread();
+
+        d.recordSet("CONFIG", t);
+        d.recordRead("CONFIG", t);
+        assertFalse(d.analyze().hasIssues());
+    }
+
+    // ---- StructuredTaskScopeMisuseDetector (JEP 505) ----
+
+    @Test
+    void structuredTaskScope_detector_public_api_flags_fork_after_join() {
+        var d = new StructuredTaskScopeMisuseDetector();
+        Thread owner = Thread.currentThread();
+
+        d.recordScopeOpened("s", owner);
+        d.recordFork("s", "a", owner);
+        d.recordJoin("s", owner);
+        d.recordFork("s", "late", owner);          // fork after join
+
+        var report = d.analyze();
+        assertTrue(report.hasIssues());
+        assertEquals(1, report.getForkAfterJoinIssues().size());
+        assertEquals(1, report.getTotalScopes());
+    }
+
+    @Test
+    void structuredTaskScope_detector_clean_for_correct_lifecycle() {
+        var d = new StructuredTaskScopeMisuseDetector();
+        Thread owner = Thread.currentThread();
+
+        d.recordScopeOpened("s", owner);
+        d.recordFork("s", "a", owner);
+        d.recordJoin("s", owner);
+        d.recordResultRead("s", "a", owner);
+        d.recordScopeClosed("s", owner);
+        assertFalse(d.analyze().hasIssues());
+    }
+
+    // ---- GathererConcurrencyMisuseDetector (JEP 485) ----
+
+    @Test
+    void gatherer_detector_public_api_flags_missing_combiner_across_threads() throws Exception {
+        var d = new GathererConcurrencyMisuseDetector();
+        d.registerGatherer("g", /*hasCombiner*/ false, /*parallel*/ true);
+
+        Thread a = new Thread(() -> d.recordIntegrate("g", Thread.currentThread()));
+        Thread b = new Thread(() -> d.recordIntegrate("g", Thread.currentThread()));
+        a.start(); b.start();
+        a.join(); b.join();
+
+        var report = d.analyze();
+        assertTrue(report.hasIssues());
+        assertFalse(report.getMissingCombinerIssues().isEmpty());
+    }
+
+    @Test
+    void gatherer_detector_clean_on_single_thread() {
+        var d = new GathererConcurrencyMisuseDetector();
+        d.registerGatherer("g", false, false);
+        d.recordIntegrate("g", Thread.currentThread());
+        assertFalse(d.analyze().hasIssues());
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -291,6 +291,42 @@ Shows the structure and common pattern of all detectors.
 
 ---
 
+## JDK 25/26 Preview-Era Detectors (Standalone, 1.7.0+)
+
+Three detectors target concurrency features introduced or finalized in JDK 24–26.
+They follow the **same `recordXxx(...)` → `analyze(): Report` pattern** as every other
+diagnostics detector and are thread-safe (`ConcurrentHashMap` / `newKeySet`-backed), but
+they are deliberately **not wired into the `@AsyncTest` execution pipeline**:
+
+- `se.deversity.asynctest.diagnostics.StableValueMisuseDetector` — `StableValue`
+  (JEP 502, preview JDK 25 → JDK 26): read-before-set, double-set, reentrant
+  `orElseSet` supplier, set-contention.
+- `se.deversity.asynctest.diagnostics.StructuredTaskScopeMisuseDetector` —
+  `StructuredTaskScope` (JEP 505, fifth preview JDK 25 → final JDK 26): fork-after-join,
+  `Subtask.get()` before join, owner-confinement violation, close-without-join.
+- `se.deversity.asynctest.diagnostics.GathererConcurrencyMisuseDetector` — Stream
+  Gatherers (JEP 485, final JDK 24): stateful gatherer on a parallel stream with no
+  combiner, concurrent-integrator shared-state race.
+
+**Why standalone, not pipeline-wired.** Every pipeline detector is addressable via a
+`DetectorType` enum constant (used by `excludes` / `includes` / `Preset` / the SPI's
+`type()`). `DetectorType` is an `@AILocked` file: adding a constant requires the
+synchronized six-place change documented in `CLAUDE.md` (annotation field, config field +
+builder default, `from(AsyncTest)`, both `build()` branches, and the registry arm). Rather
+than make that locked change in isolation, these three ship as standalone, directly-usable
+detectors. They are implemented entirely against `String` keys and `Thread` (no
+`java.lang.StableValue` / new `StructuredTaskScope` imports), so they **compile and run on
+the project's Java 21 baseline** while modeling APIs that only exist on JDK 24/25/26.
+
+**Usage.** Instantiate the detector (one instance can be shared across an `@AsyncTest`'s
+worker threads), call its `recordXxx(...)` methods from the test body, then call
+`analyze()` and assert on the returned report's `hasIssues()`. To promote any of them to a
+full pipeline detector once a `DetectorType` slot is available: add the enum constant +
+config flag, then either add an `AsyncTestContext` accessor (legacy path) or a
+`DetectorFactory` + `META-INF/services` line (SPI path) — see [Detector SPI](#detector-spi-100).
+
+---
+
 ## Key Design Patterns
 
 ### 1. ThreadLocal Context Pattern
@@ -602,6 +638,9 @@ src/main/java/se/deversity/asynctest/
 │   ├── SharedSecureRandomDetector.java    # NEW in 1.6.0 — Phase 13
 │   ├── WeakHashMapSharedDetector.java     # NEW in 1.6.0 — Phase 13
 │   ├── JdbcConnectionSharedDetector.java  # NEW in 1.6.0 — Phase 13
+│   ├── StableValueMisuseDetector.java          # NEW in 1.7.0 — standalone, JDK 25/26 (JEP 502)
+│   ├── StructuredTaskScopeMisuseDetector.java  # NEW in 1.7.0 — standalone, JDK 25/26 (JEP 505)
+│   ├── GathererConcurrencyMisuseDetector.java  # NEW in 1.7.0 — standalone, JDK 24+ (JEP 485)
 ├── report/                           # NEW package in 1.6.0 — structured reporting
 │   ├── Violation.java                # (detector, severity, message, sites, attributes, when)
 │   ├── Formatter.java                # functional interface List<Violation> → String

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — JDK 25/26 standalone detectors
+- **Three new concurrency detectors** for features introduced/finalized in JDK 24–26,
+  shipped as **standalone** diagnostics (used directly via `recordXxx(...)` → `analyze()`),
+  not wired into the `@AsyncTest` `detectAll` pipeline — a pipeline detector needs a
+  `DetectorType` enum constant and that enum is a locked file:
+  - `StableValueMisuseDetector` — `StableValue` (JEP 502, preview JDK 25 → 26):
+    read-before-set, double-set, reentrant `orElseSet`, set-contention.
+  - `StructuredTaskScopeMisuseDetector` — `StructuredTaskScope.open(Joiner)` (JEP 505,
+    preview JDK 25 → final JDK 26): fork-after-join, result-before-join, owner-confinement,
+    close-without-join.
+  - `GathererConcurrencyMisuseDetector` — Stream Gatherers (JEP 485, final JDK 24):
+    stateful gatherer on a parallel stream without a combiner, concurrent-integrator races.
+- Each detector compiles on the Java 21 baseline (modeled via `String` keys + `Thread`,
+  no preview-API imports), with full JUnit 5 test suites (34 tests).
+- Documentation: README detector table, `.claude/SKILL.md`, `docs/ARCHITECTURE.md`,
+  `docs/DETECTOR_CATALOG.md`; examples **114–116** (`stable-value-misuse`,
+  `structured-task-scope-misuse`, `gatherer-parallel-misuse`); and a
+  `ConsumerJdk25And26DetectorsTest` public-surface fixture.
+
 ## [1.7.0-RC1] - 2026-06-13
 
 ### Added — Concurrency Detectors (Phases 11 & 12)

--- a/docs/DETECTOR_CATALOG.md
+++ b/docs/DETECTOR_CATALOG.md
@@ -217,3 +217,113 @@ Detectors that observe unsafe usages of JDK classes and concurrent collections.
 | **Phase 10**| Collection Safety | 10 | SynchronizedCollection, CopyOnWrite, MutableKey | `HIGH` |
 | **Phase 11**| System / Global | 10 | SystemPropertyMutation, ExplicitGC, MDCLeak | `LOW`/`MEDIUM` |
 | **Phase 12**| Miscellaneous | 12 | Statefulness, StreamClosing, WeakReferenceRace | `LOW`/`MEDIUM` |
+
+---
+
+## JDK 25/26 Preview-Era Detectors (Standalone)
+
+Three detectors target concurrency features introduced or finalized in **JDK 24–26**.
+Unlike the catalog above, these are **not** part of the `@AsyncTest` `detectAll`
+pipeline — a pipeline detector needs a `DetectorType` enum constant, and that enum is a
+locked file. They ship in `se.deversity.asynctest.diagnostics` and are used **directly**:
+instantiate, record events from your test body, call `analyze()`, and assert on the
+report. Each is implemented against `String` keys + `Thread` (no preview-API imports), so
+it compiles and runs on the Java 21 baseline while modeling APIs that only exist on
+JDK 24/25/26.
+
+### A. StableValue Misuse Detector
+* **Class**: `StableValueMisuseDetector` · **JDK feature**: `StableValue` (JEP 502, preview JDK 25 → 26)
+* **Severity**: `CRITICAL` (read-before-set / reentrant) · `HIGH` (double-set) · `LOW` (contention)
+* **Description**: `StableValue<T>` is a deferred-immutable holder set at most once, then
+  constant-folded by the JVM — the modern replacement for double-checked-locking and
+  holder-class lazy init. The detector flags accesses that break the at-most-once contract.
+* **Buggy Code**:
+  ```java
+  static final StableValue<Config> CONFIG = StableValue.of();
+
+  Config get() {
+      return CONFIG.orElseThrow();   // BUG: read before any set → NoSuchElementException
+  }
+  void init() {
+      CONFIG.setOrThrow(load());
+      CONFIG.setOrThrow(reload());   // BUG: second set → IllegalStateException / lost update
+  }
+  ```
+* **Fixed Code**:
+  ```java
+  static final StableValue<Config> CONFIG = StableValue.of();
+
+  Config get() {
+      return CONFIG.orElseSet(() -> load());  // lazy, at-most-once, thread-safe; pure supplier
+  }
+  ```
+* **Detect**:
+  ```java
+  var d = new StableValueMisuseDetector();
+  d.recordRead("CONFIG", Thread.currentThread());          // before any recordSet → flagged
+  d.recordSet("CONFIG", Thread.currentThread());
+  d.recordSet("CONFIG", Thread.currentThread());           // double set → flagged
+  assertTrue(d.analyze().hasIssues());
+  ```
+
+### B. StructuredTaskScope Misuse Detector
+* **Class**: `StructuredTaskScopeMisuseDetector` · **JDK feature**: `StructuredTaskScope` (JEP 505, preview JDK 25 → final JDK 26)
+* **Severity**: `CRITICAL` (lifecycle violations) · `HIGH` (close-without-join)
+* **Description**: The JDK 25 API (`StructuredTaskScope.open(Joiner)`) enforces a strict
+  `open → fork* → join → get* → close` lifecycle. The detector models each scope as a small
+  state machine and flags the transitions the runtime rejects.
+* **Buggy Code**:
+  ```java
+  try (var scope = StructuredTaskScope.open(Joiner.<String>allSuccessfulOrThrow())) {
+      Subtask<String> a = scope.fork(() -> fetchA());
+      String early = a.get();        // BUG: read before join() → IllegalStateException
+      scope.join();
+      scope.fork(() -> fetchB());    // BUG: fork after join() → IllegalStateException
+  }   // (also: closing without join() would cancel running subtasks)
+  ```
+* **Fixed Code**:
+  ```java
+  try (var scope = StructuredTaskScope.open(Joiner.<String>allSuccessfulOrThrow())) {
+      Subtask<String> a = scope.fork(() -> fetchA());
+      Subtask<String> b = scope.fork(() -> fetchB());
+      scope.join();                              // wait first
+      return combine(a.get(), b.get());          // then read
+  }
+  ```
+* **Detect**:
+  ```java
+  var d = new StructuredTaskScopeMisuseDetector();
+  Thread owner = Thread.currentThread();
+  d.recordScopeOpened("s", owner);
+  d.recordFork("s", "a", owner);
+  d.recordJoin("s", owner);
+  d.recordFork("s", "late", owner);              // fork after join → flagged
+  assertTrue(d.analyze().hasIssues());
+  ```
+
+### C. Gatherer Concurrency Misuse Detector
+* **Class**: `GathererConcurrencyMisuseDetector` · **JDK feature**: Stream Gatherers (JEP 485, final JDK 24)
+* **Severity**: `HIGH` (missing combiner) · `MEDIUM` (concurrent integrator)
+* **Description**: On a parallel stream the runtime splits the input, runs the integrator on
+  independent per-thread state, then merges with the **combiner**. A stateful gatherer with
+  no combiner (or one whose integrator touches shared state) silently loses or corrupts
+  results. The detector confirms multi-thread execution and judges whether it was safe.
+* **Buggy Code**:
+  ```java
+  // Stateful integrator, NO combiner, used on a parallel stream → states can't merge
+  Gatherer<T,?,R> g = Gatherer.ofSequential(initializer, integrator, finisher);
+  list.parallelStream().gather(g).toList();   // forced sequential, or silently wrong if hand-rolled
+  ```
+* **Fixed Code**:
+  ```java
+  // Provide a combiner so per-thread states merge safely under parallelism:
+  Gatherer<T,?,R> g = Gatherer.of(initializer, integrator, combiner, finisher);
+  list.parallelStream().gather(g).toList();
+  ```
+* **Detect**:
+  ```java
+  var d = new GathererConcurrencyMisuseDetector();
+  d.registerGatherer("running", /*hasCombiner*/ false, /*parallel*/ true);
+  // integrator calls d.recordIntegrate("running", Thread.currentThread()) per element
+  assertTrue(d.analyze().hasIssues());   // fires once seen on >1 thread without a combiner
+  ```

--- a/examples/114-stable-value-misuse/README.md
+++ b/examples/114-stable-value-misuse/README.md
@@ -1,0 +1,72 @@
+# Example 114 — StableValue Misuse (JDK 25/26, JEP 502)
+
+**Detector**: `StableValueMisuseDetector` (standalone — not pipeline-wired)
+**JDK feature**: `java.lang.StableValue` — JEP 502, preview in JDK 25, continuing in JDK 26
+
+## The Problem
+
+`StableValue<T>` is a *deferred-immutable* holder: unset at construction, settable **at
+most once**, then treated by the JVM as a true constant (constant-folded like a `final`
+field) — the modern, thread-safe replacement for double-checked locking and holder-class
+lazy initialization. Its guarantees only hold if you respect the at-most-once contract:
+
+- **Read before set** — `orElseThrow()` / `get()` before any value is set throws
+  `NoSuchElementException`. Under concurrency this is a publication race: a reader can
+  observe the holder before the writer's set happens-before the read.
+- **Double set** — a second `setOrThrow(...)` after the holder is set throws
+  `IllegalStateException`; `trySet(...)` silently drops the second value (a lost update).
+- **Reentrant `orElseSet`** — a supplier that reads the same `StableValue` while it is
+  still computing deadlocks / throws.
+
+## The buggy pattern (real JDK 25/26 API)
+
+```java
+static final StableValue<Config> CONFIG = StableValue.of();
+
+Config get()  { return CONFIG.orElseThrow(); }   // ✗ read before set → NoSuchElementException
+void   init() {
+    CONFIG.setOrThrow(load());
+    CONFIG.setOrThrow(reload());                  // ✗ second set → IllegalStateException
+}
+```
+
+> This example models `StableValue` with an `AtomicReference` in
+> [`StableValueConfigService`](src/main/java/se/deversity/asynctest/example/service/StableValueConfigService.java)
+> so it compiles and runs on the Java 21 baseline. The detector itself is API-agnostic —
+> it works off recorded events, so it applies unchanged to the real `StableValue`.
+
+## The Fix
+
+```java
+static final StableValue<Config> CONFIG = StableValue.of();
+
+Config get() {
+    return CONFIG.orElseSet(() -> load());   // lazy, at-most-once, thread-safe, pure supplier
+}
+```
+
+## How to Detect
+
+`StableValueMisuseDetector` is standalone — instantiate it, record events around the
+holder, then assert on `analyze()`:
+
+```java
+var d = new StableValueMisuseDetector();
+d.recordRead("CONFIG", Thread.currentThread());   // before any set → flagged
+d.recordSet("CONFIG", Thread.currentThread());
+d.recordSet("CONFIG", Thread.currentThread());    // double set → flagged
+assertTrue(d.analyze().hasIssues());
+```
+
+See [`StableValueConfigServiceTest`](src/test/java/se/deversity/asynctest/example/StableValueConfigServiceTest.java)
+for the full happy-path / read-before-set / double-set walkthrough.
+
+## Running
+
+These detectors ship in the in-progress build. Install the parent artifact to your local
+Maven repo first (same workflow as `consumer-fixture`):
+
+```bash
+mvn -f ../../pom.xml install -DskipTests -Dlicense.mock.mode=true
+mvn -f pom.xml test
+```

--- a/examples/114-stable-value-misuse/pom.xml
+++ b/examples/114-stable-value-misuse/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>se.deversity.async-test-lib</groupId>
+    <artifactId>async-example-stable-value-misuse</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Async Test Lib - StableValue Misuse Example (JDK 25/26)</name>
+    <description>Demonstrates StableValueMisuseDetector (standalone): a StableValue is read before it is set and set more than once — read-before-set, double-set, and reentrant-orElseSet hazards from JEP 502.</description>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.10.2</junit.version>
+        <async-test-lib.version>1.7.0-RC1</async-test-lib.version>
+    </properties>
+    <dependencies>
+        <dependency><groupId>se.deversity.async-test-lib</groupId><artifactId>async-test-lib</artifactId><version>${async-test-lib.version}</version><scope>test</scope></dependency>
+        <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>${junit.version}</version><scope>test</scope></dependency>
+    </dependencies>
+    <build><plugins>
+        <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><version>3.13.0</version></plugin>
+        <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-surefire-plugin</artifactId><version>3.2.5</version>
+            <configuration><systemPropertyVariables><license.mock.mode>true</license.mock.mode></systemPropertyVariables></configuration>
+        </plugin>
+    </plugins></build>
+</project>

--- a/examples/114-stable-value-misuse/src/main/java/se/deversity/asynctest/example/service/StableValueConfigService.java
+++ b/examples/114-stable-value-misuse/src/main/java/se/deversity/asynctest/example/service/StableValueConfigService.java
@@ -1,0 +1,49 @@
+package se.deversity.asynctest.example.service;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * Models a {@code StableValue<Config>}-backed lazy config holder (JEP 502).
+ *
+ * <p>The real JDK 25/26 type is {@code java.lang.StableValue}, a deferred-immutable
+ * holder set at most once and then constant-folded by the JVM. Because that type is a
+ * preview API not present on the Java 21 baseline this example targets, the holder here
+ * is modeled with an {@link AtomicReference} that mirrors the same semantics: unset until
+ * the first set, settable once, read via {@link #orElseThrow()} / lazy {@link #orElseSet}.
+ *
+ * <p>The class deliberately exposes both the <em>buggy</em> access patterns (read before
+ * set, double set) and the <em>correct</em> one ({@link #orElseSet}) so the test can drive
+ * each and surface the difference with {@code StableValueMisuseDetector}.
+ */
+public final class StableValueConfigService {
+
+    /** The deferred-immutable holder (models StableValue&lt;String&gt;). */
+    private final AtomicReference<String> config = new AtomicReference<>(null);
+
+    /** Models {@code StableValue.orElseThrow()} — throws if read before any set. */
+    public String orElseThrow() {
+        String v = config.get();
+        if (v == null) {
+            throw new java.util.NoSuchElementException("config not set");
+        }
+        return v;
+    }
+
+    /** Models {@code StableValue.setOrThrow(value)} — throws on a second set. */
+    public void setOrThrow(String value) {
+        if (!config.compareAndSet(null, value)) {
+            throw new IllegalStateException("config already set");
+        }
+    }
+
+    /** Models {@code StableValue.orElseSet(supplier)} — lazy, at-most-once, thread-safe. */
+    public String orElseSet(Supplier<String> supplier) {
+        String v = config.get();
+        if (v != null) {
+            return v;
+        }
+        String computed = supplier.get();
+        return config.compareAndSet(null, computed) ? computed : config.get();
+    }
+}

--- a/examples/114-stable-value-misuse/src/test/java/se/deversity/asynctest/example/StableValueConfigServiceTest.java
+++ b/examples/114-stable-value-misuse/src/test/java/se/deversity/asynctest/example/StableValueConfigServiceTest.java
@@ -1,0 +1,95 @@
+package se.deversity.asynctest.example;
+
+import se.deversity.asynctest.diagnostics.StableValueMisuseDetector;
+import se.deversity.asynctest.example.service.StableValueConfigService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test for StableValueConfigService.
+ *
+ * ========================================================================
+ * DETECTOR: StableValueMisuseDetector  (standalone — JDK 25/26, JEP 502)
+ * ========================================================================
+ *
+ * StableValueMisuseDetector is NOT wired into the @AsyncTest detectAll pipeline
+ * (a pipeline detector needs a DetectorType enum constant, and that enum is a
+ * locked file). It is used directly: instantiate it, record events around the
+ * holder under test, then call analyze() and assert on the report.
+ *
+ * THE BUG:
+ *   - orElseThrow() called before the value was ever set → NoSuchElementException
+ *   - setOrThrow() called twice → IllegalStateException / lost update
+ *
+ * THE FIX:
+ *   - Use orElseSet(supplier): lazy, at-most-once, thread-safe, with a pure supplier.
+ */
+class StableValueConfigServiceTest {
+
+    private StableValueConfigService service;
+    private StableValueMisuseDetector detector;
+
+    @BeforeEach
+    void setUp() {
+        service = new StableValueConfigService();
+        detector = new StableValueMisuseDetector();
+    }
+
+    // -----------------------------------------------------------------------
+    // Part 1: correct usage — orElseSet, then read. No misuse.
+    // -----------------------------------------------------------------------
+
+    @Test
+    void correctUsage_orElseSet_thenRead_isClean() {
+        Thread t = Thread.currentThread();
+
+        detector.recordSupplierStart("CONFIG", t);
+        String value = service.orElseSet(() -> "db-url=localhost");
+        detector.recordSupplierEnd("CONFIG", t);
+
+        detector.recordRead("CONFIG", t);
+        assertEquals("db-url=localhost", service.orElseThrow());
+
+        var report = detector.analyze();
+        assertFalse(report.hasIssues(), () -> "Expected clean usage:\n" + report);
+    }
+
+    // -----------------------------------------------------------------------
+    // Part 2: read before set — NoSuchElementException risk, caught by the detector.
+    // -----------------------------------------------------------------------
+
+    @Test
+    void readBeforeSet_isDetected() {
+        Thread t = Thread.currentThread();
+
+        detector.recordRead("CONFIG", t);                 // BUG: nothing set yet
+        assertThrows(java.util.NoSuchElementException.class, () -> service.orElseThrow());
+
+        var report = detector.analyze();
+        assertTrue(report.hasIssues());
+        assertFalse(report.getReadBeforeSetIssues().isEmpty());
+        assertTrue(report.getReadBeforeSetIssues().get(0).contains("NoSuchElementException"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Part 3: double set — second setOrThrow is a lost update, caught by the detector.
+    // -----------------------------------------------------------------------
+
+    @Test
+    void doubleSet_isDetected() {
+        Thread t = Thread.currentThread();
+
+        detector.recordSet("CONFIG", t);
+        service.setOrThrow("first");
+
+        detector.recordSet("CONFIG", t);                  // BUG: second set
+        assertThrows(IllegalStateException.class, () -> service.setOrThrow("second"));
+
+        var report = detector.analyze();
+        assertTrue(report.hasIssues());
+        assertEquals(1, report.getDoubleSetIssues().size());
+        assertEquals("first", service.orElseThrow(), "first writer wins; second value is lost");
+    }
+}

--- a/examples/115-structured-task-scope-misuse/README.md
+++ b/examples/115-structured-task-scope-misuse/README.md
@@ -1,0 +1,75 @@
+# Example 115 — StructuredTaskScope Misuse (JDK 25/26, JEP 505)
+
+**Detector**: `StructuredTaskScopeMisuseDetector` (standalone — not pipeline-wired)
+**JDK feature**: `java.util.concurrent.StructuredTaskScope` — JEP 505, fifth preview in
+JDK 25, on track to finalize in JDK 26
+
+## The Problem
+
+The JDK 25 API reshapes structured concurrency around a factory and a pluggable `Joiner`,
+and enforces a strict lifecycle:
+
+```
+open → fork* → join → get* → close   (try-with-resources)
+```
+
+Breaking it does not merely produce a wrong result — the runtime throws, leaks subtasks, or
+returns a value read from an incomplete subtask:
+
+| Misuse | Result |
+|--------|--------|
+| `fork()` after `join()` | `IllegalStateException` — scope no longer accepts work |
+| `Subtask.get()` before `join()` | `IllegalStateException` — partial / unpublished result |
+| `fork()` / `join()` off-owner thread | `WrongThreadException` — scope is confined to its owner |
+| `close()` without `join()` | running subtasks are cancelled; their work is abandoned |
+
+## The buggy pattern (real JDK 25 API)
+
+```java
+try (var scope = StructuredTaskScope.open(Joiner.<String>allSuccessfulOrThrow())) {
+    Subtask<String> a = scope.fork(() -> fetchA());
+    String early = a.get();        // ✗ read before join() → IllegalStateException
+    scope.join();
+    scope.fork(() -> fetchB());    // ✗ fork after join() → IllegalStateException
+}
+```
+
+> `StructuredTaskScope.open(Joiner)` is a preview API not on the Java 21 baseline this
+> example targets, so [`ParallelFetchService`](src/main/java/se/deversity/asynctest/example/service/ParallelFetchService.java)
+> performs the fan-out with a virtual-thread-per-task `ExecutorService`. The lifecycle rules
+> are identical; the test models them with the detector.
+
+## The Fix
+
+```java
+try (var scope = StructuredTaskScope.open(Joiner.<String>allSuccessfulOrThrow())) {
+    Subtask<String> a = scope.fork(() -> fetchA());
+    Subtask<String> b = scope.fork(() -> fetchB());
+    scope.join();                              // wait first
+    return combine(a.get(), b.get());          // then read
+}
+```
+
+## How to Detect
+
+`StructuredTaskScopeMisuseDetector` is standalone — record lifecycle events, then assert:
+
+```java
+var d = new StructuredTaskScopeMisuseDetector();
+Thread owner = Thread.currentThread();
+d.recordScopeOpened("s", owner);
+d.recordFork("s", "a", owner);
+d.recordJoin("s", owner);
+d.recordFork("s", "late", owner);     // fork after join → flagged
+assertTrue(d.analyze().hasIssues());
+```
+
+See [`ParallelFetchServiceTest`](src/test/java/se/deversity/asynctest/example/ParallelFetchServiceTest.java)
+for all four lifecycle violations plus the clean path.
+
+## Running
+
+```bash
+mvn -f ../../pom.xml install -DskipTests -Dlicense.mock.mode=true
+mvn -f pom.xml test
+```

--- a/examples/115-structured-task-scope-misuse/pom.xml
+++ b/examples/115-structured-task-scope-misuse/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>se.deversity.async-test-lib</groupId>
+    <artifactId>async-example-structured-task-scope-misuse</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Async Test Lib - StructuredTaskScope Misuse Example (JDK 25/26)</name>
+    <description>Demonstrates StructuredTaskScopeMisuseDetector (standalone): the JDK 25 StructuredTaskScope.open(Joiner) lifecycle is violated — fork-after-join, result-before-join, owner-confinement, and close-without-join from JEP 505.</description>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.10.2</junit.version>
+        <async-test-lib.version>1.7.0-RC1</async-test-lib.version>
+    </properties>
+    <dependencies>
+        <dependency><groupId>se.deversity.async-test-lib</groupId><artifactId>async-test-lib</artifactId><version>${async-test-lib.version}</version><scope>test</scope></dependency>
+        <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>${junit.version}</version><scope>test</scope></dependency>
+    </dependencies>
+    <build><plugins>
+        <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><version>3.13.0</version></plugin>
+        <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-surefire-plugin</artifactId><version>3.2.5</version>
+            <configuration><systemPropertyVariables><license.mock.mode>true</license.mock.mode></systemPropertyVariables></configuration>
+        </plugin>
+    </plugins></build>
+</project>

--- a/examples/115-structured-task-scope-misuse/src/main/java/se/deversity/asynctest/example/service/ParallelFetchService.java
+++ b/examples/115-structured-task-scope-misuse/src/main/java/se/deversity/asynctest/example/service/ParallelFetchService.java
@@ -1,0 +1,49 @@
+package se.deversity.asynctest.example.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * Models a structured fan-out over a {@code StructuredTaskScope} (JEP 505).
+ *
+ * <p>The real JDK 25 API is:
+ * <pre>{@code
+ * try (var scope = StructuredTaskScope.open(Joiner.<String>allSuccessfulOrThrow())) {
+ *     var subtasks = ids.stream().map(id -> scope.fork(() -> fetch(id))).toList();
+ *     scope.join();
+ *     return subtasks.stream().map(Subtask::get).toList();
+ * }
+ * }</pre>
+ *
+ * <p>{@code StructuredTaskScope.open(Joiner)} is a JDK 25 preview API not present on the
+ * Java 21 baseline this example targets, so the fan-out here uses a virtual-thread-per-task
+ * {@link ExecutorService}. The lifecycle rules being demonstrated — fork → join → get,
+ * confined to the owner thread — are identical; the test models them with
+ * {@code StructuredTaskScopeMisuseDetector}.
+ */
+public final class ParallelFetchService {
+
+    /** Correct: fork all, await all, then read results. */
+    public List<String> fetchAll(List<String> ids) throws Exception {
+        try (ExecutorService scope = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<String>> subtasks = new ArrayList<>();
+            for (String id : ids) {
+                subtasks.add(scope.submit(() -> fetch(id)));   // fork
+            }
+            // try-with-resources close() awaits termination — our "join"
+            scope.shutdown();
+            List<String> results = new ArrayList<>();
+            for (Future<String> s : subtasks) {
+                results.add(s.get());                          // read after join
+            }
+            return results;
+        }
+    }
+
+    private String fetch(String id) {
+        return "result-for-" + id;
+    }
+}

--- a/examples/115-structured-task-scope-misuse/src/test/java/se/deversity/asynctest/example/ParallelFetchServiceTest.java
+++ b/examples/115-structured-task-scope-misuse/src/test/java/se/deversity/asynctest/example/ParallelFetchServiceTest.java
@@ -1,0 +1,135 @@
+package se.deversity.asynctest.example;
+
+import se.deversity.asynctest.diagnostics.StructuredTaskScopeMisuseDetector;
+import se.deversity.asynctest.example.service.ParallelFetchService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test for ParallelFetchService.
+ *
+ * ========================================================================
+ * DETECTOR: StructuredTaskScopeMisuseDetector  (standalone — JDK 25/26, JEP 505)
+ * ========================================================================
+ *
+ * The JDK 25 StructuredTaskScope.open(Joiner) API enforces a strict lifecycle:
+ *
+ *     open → fork* → join → get* → close   (try-with-resources)
+ *
+ * Breaking it does not just produce a bad result — it throws, leaks subtasks, or
+ * reads from an incomplete subtask. StructuredTaskScopeMisuseDetector models each
+ * scope as a state machine and flags the transitions the runtime rejects:
+ *
+ *   - fork() after join()          → IllegalStateException
+ *   - Subtask.get() before join()  → IllegalStateException (partial result)
+ *   - fork()/join() off-owner      → WrongThreadException (scope is confined)
+ *   - close() without join()       → running subtasks cancelled, work lost
+ *
+ * The detector is standalone (not wired into @AsyncTest) — instantiate it, record
+ * lifecycle events, then assert on analyze().
+ */
+class ParallelFetchServiceTest {
+
+    private ParallelFetchService service;
+    private StructuredTaskScopeMisuseDetector detector;
+
+    @BeforeEach
+    void setUp() {
+        service = new ParallelFetchService();
+        detector = new StructuredTaskScopeMisuseDetector();
+    }
+
+    // -----------------------------------------------------------------------
+    // Part 1: correct lifecycle — open, fork, join, read, close. No misuse.
+    // -----------------------------------------------------------------------
+
+    @Test
+    void correctLifecycle_isClean() throws Exception {
+        Thread owner = Thread.currentThread();
+
+        detector.recordScopeOpened("fetch", owner);
+        detector.recordFork("fetch", "a", owner);
+        detector.recordFork("fetch", "b", owner);
+        List<String> results = service.fetchAll(List.of("a", "b"));   // real fan-out
+        detector.recordJoin("fetch", owner);
+        detector.recordResultRead("fetch", "a", owner);
+        detector.recordResultRead("fetch", "b", owner);
+        detector.recordScopeClosed("fetch", owner);
+
+        assertEquals(List.of("result-for-a", "result-for-b"), results);
+        assertFalse(detector.analyze().hasIssues(), () -> "Expected clean lifecycle:\n" + detector.analyze());
+    }
+
+    // -----------------------------------------------------------------------
+    // Part 2: fork after join — the scope no longer accepts work.
+    // -----------------------------------------------------------------------
+
+    @Test
+    void forkAfterJoin_isDetected() {
+        Thread owner = Thread.currentThread();
+        detector.recordScopeOpened("fetch", owner);
+        detector.recordFork("fetch", "a", owner);
+        detector.recordJoin("fetch", owner);
+        detector.recordFork("fetch", "late", owner);   // BUG: fork after join
+
+        var report = detector.analyze();
+        assertTrue(report.hasIssues());
+        assertEquals(1, report.getForkAfterJoinIssues().size());
+        assertTrue(report.getForkAfterJoinIssues().get(0).contains("IllegalStateException"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Part 3: result read before join — may read a partial result.
+    // -----------------------------------------------------------------------
+
+    @Test
+    void resultBeforeJoin_isDetected() {
+        Thread owner = Thread.currentThread();
+        detector.recordScopeOpened("fetch", owner);
+        detector.recordFork("fetch", "a", owner);
+        detector.recordResultRead("fetch", "a", owner);  // BUG: read before join
+
+        var report = detector.analyze();
+        assertTrue(report.hasIssues());
+        assertEquals(1, report.getResultBeforeJoinIssues().size());
+    }
+
+    // -----------------------------------------------------------------------
+    // Part 4: owner confinement — fork from a non-owner thread.
+    // -----------------------------------------------------------------------
+
+    @Test
+    void forkFromNonOwnerThread_isDetected() throws Exception {
+        Thread owner = Thread.currentThread();
+        detector.recordScopeOpened("fetch", owner);
+
+        Thread other = new Thread(() -> detector.recordFork("fetch", "x", Thread.currentThread()));
+        other.start();
+        other.join();
+
+        var report = detector.analyze();
+        assertTrue(report.hasIssues());
+        assertEquals(1, report.getConfinementIssues().size());
+        assertTrue(report.getConfinementIssues().get(0).contains("WrongThreadException"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Part 5: close without join — running subtasks are cancelled.
+    // -----------------------------------------------------------------------
+
+    @Test
+    void closeWithoutJoin_isDetected() {
+        Thread owner = Thread.currentThread();
+        detector.recordScopeOpened("fetch", owner);
+        detector.recordFork("fetch", "a", owner);
+        detector.recordScopeClosed("fetch", owner);     // BUG: never joined
+
+        var report = detector.analyze();
+        assertTrue(report.hasIssues());
+        assertEquals(1, report.getMissingJoinIssues().size());
+    }
+}

--- a/examples/116-gatherer-parallel-misuse/README.md
+++ b/examples/116-gatherer-parallel-misuse/README.md
@@ -1,0 +1,68 @@
+# Example 116 — Gatherer Parallel Misuse (JDK 24+, JEP 485)
+
+**Detector**: `GathererConcurrencyMisuseDetector` (standalone — not pipeline-wired)
+**JDK feature**: `Stream.gather(Gatherer)` — JEP 485, finalized in JDK 24, the standard
+custom intermediate-operation extension point in JDK 25/26
+
+## The Problem
+
+A `Gatherer` has four parts: an `initializer` (per-thread private state), an `integrator`,
+an optional `combiner`, and an optional `finisher`. On a **parallel** stream the runtime:
+
+1. splits the input,
+2. runs the integrator on independent state per worker thread,
+3. merges those states with the **combiner**.
+
+The dangerous combination is a **stateful** gatherer with **no combiner** (or one whose
+integrator mutates shared/captured state) running on a parallel stream. The per-thread
+states can't be merged, so results are silently dropped, duplicated, or non-deterministic —
+and shared mutable state races across the split.
+
+## The buggy pattern (real JDK 24+ API)
+
+```java
+Gatherer<T,?,T> runningDistinct = Gatherer.ofSequential(
+    HashSet::new,
+    (state, elem, downstream) -> state.add(elem) ? downstream.push(elem) : true);
+
+list.parallelStream().gather(runningDistinct).toList();   // ✗ no combiner → can't merge
+```
+
+> `Stream.gather` / `java.util.stream.Gatherer` are not on the Java 21 baseline this
+> example targets, so [`RunningDistinctService`](src/main/java/se/deversity/asynctest/example/service/RunningDistinctService.java)
+> shows the same hazard with a stateful `filter(seen::add)` over a shared `HashSet` on a
+> parallel stream. The detector is event-based, so it applies unchanged to a real `Gatherer`.
+
+## The Fix
+
+```java
+// Stateful + parallel-safe → supply a combiner so per-thread states merge:
+Gatherer<T,?,R> g = Gatherer.of(initializer, integrator, combiner, finisher);
+
+// Or, when there is no safe merge, force sequential evaluation:
+Gatherer<T,?,R> g = Gatherer.ofSequential(initializer, integrator, finisher);
+```
+
+Keep all mutation inside the per-thread state from the initializer; never touch
+captured/shared state from the integrator.
+
+## How to Detect
+
+Declare the gatherer's shape, then record each integrator invocation:
+
+```java
+var d = new GathererConcurrencyMisuseDetector();
+d.registerGatherer("running-distinct", /*hasCombiner*/ false, /*parallel*/ true);
+// integrator: d.recordIntegrate("running-distinct", Thread.currentThread());
+assertTrue(d.analyze().hasIssues());   // fires once seen on >1 thread without a combiner
+```
+
+See [`RunningDistinctServiceTest`](src/test/java/se/deversity/asynctest/example/RunningDistinctServiceTest.java)
+for the safe-vs-buggy comparison.
+
+## Running
+
+```bash
+mvn -f ../../pom.xml install -DskipTests -Dlicense.mock.mode=true
+mvn -f pom.xml test
+```

--- a/examples/116-gatherer-parallel-misuse/pom.xml
+++ b/examples/116-gatherer-parallel-misuse/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>se.deversity.async-test-lib</groupId>
+    <artifactId>async-example-gatherer-parallel-misuse</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Async Test Lib - Gatherer Parallel Misuse Example (JDK 24+)</name>
+    <description>Demonstrates GathererConcurrencyMisuseDetector (standalone): a stateful Stream Gatherer (JEP 485) is used on a parallel stream without a combiner, so per-thread states cannot merge — lost or non-deterministic results.</description>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.10.2</junit.version>
+        <async-test-lib.version>1.7.0-RC1</async-test-lib.version>
+    </properties>
+    <dependencies>
+        <dependency><groupId>se.deversity.async-test-lib</groupId><artifactId>async-test-lib</artifactId><version>${async-test-lib.version}</version><scope>test</scope></dependency>
+        <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>${junit.version}</version><scope>test</scope></dependency>
+    </dependencies>
+    <build><plugins>
+        <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><version>3.13.0</version></plugin>
+        <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-surefire-plugin</artifactId><version>3.2.5</version>
+            <configuration><systemPropertyVariables><license.mock.mode>true</license.mock.mode></systemPropertyVariables></configuration>
+        </plugin>
+    </plugins></build>
+</project>

--- a/examples/116-gatherer-parallel-misuse/src/main/java/se/deversity/asynctest/example/service/RunningDistinctService.java
+++ b/examples/116-gatherer-parallel-misuse/src/main/java/se/deversity/asynctest/example/service/RunningDistinctService.java
@@ -1,0 +1,49 @@
+package se.deversity.asynctest.example.service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Models a stateful {@code Gatherer} used on a parallel stream (JEP 485, Stream Gatherers).
+ *
+ * <p>The real JDK 24+ shape is a custom intermediate operation:
+ * <pre>{@code
+ * Gatherer<T,?,T> runningDistinct = Gatherer.ofSequential(
+ *     HashSet::new,                                  // per-thread state
+ *     (state, elem, downstream) ->                   // integrator
+ *         state.add(elem) ? downstream.push(elem) : true);
+ * list.parallelStream().gather(runningDistinct).toList();   // ✗ no combiner → can't merge
+ * }</pre>
+ *
+ * <p>{@code Stream.gather} / {@code java.util.stream.Gatherer} are not present on the
+ * Java 21 baseline this example targets, so the stateful "running distinct" reduction is
+ * shown here with a hand-rolled integrator over a shared {@link Set}. The hazard is the
+ * same: a stateful integrator with shared state and no safe merge cannot be parallelized
+ * correctly.
+ */
+public final class RunningDistinctService {
+
+    /**
+     * BUGGY: a single shared {@link HashSet} is mutated from every worker thread while the
+     * stream runs in parallel — the gatherer equivalent of "stateful integrator, shared
+     * state, no combiner". Produces lost / duplicated output and may throw under contention.
+     */
+    public List<String> distinctParallelBuggy(List<String> input) {
+        Set<String> seen = new HashSet<>();                 // shared, non-thread-safe state
+        return input.parallelStream()
+                .filter(seen::add)                          // races across the split
+                .toList();
+    }
+
+    /**
+     * CORRECT: distinct is computed without shared mutable state. A real gatherer would
+     * supply a combiner (or use {@code Stream.distinct()} / a concurrent collector) so
+     * per-thread states merge safely.
+     */
+    public List<String> distinctParallelSafe(List<String> input) {
+        return input.parallelStream()
+                .distinct()
+                .toList();
+    }
+}

--- a/examples/116-gatherer-parallel-misuse/src/test/java/se/deversity/asynctest/example/RunningDistinctServiceTest.java
+++ b/examples/116-gatherer-parallel-misuse/src/test/java/se/deversity/asynctest/example/RunningDistinctServiceTest.java
@@ -1,0 +1,88 @@
+package se.deversity.asynctest.example;
+
+import se.deversity.asynctest.diagnostics.GathererConcurrencyMisuseDetector;
+import se.deversity.asynctest.example.service.RunningDistinctService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test for RunningDistinctService.
+ *
+ * ========================================================================
+ * DETECTOR: GathererConcurrencyMisuseDetector  (standalone — JDK 24+, JEP 485)
+ * ========================================================================
+ *
+ * On a PARALLEL stream the runtime splits the input, runs a Gatherer's integrator on
+ * independent per-thread state, then merges those states with the COMBINER. A stateful
+ * gatherer with NO combiner (or one whose integrator touches shared state) silently loses
+ * or corrupts results.
+ *
+ * GathererConcurrencyMisuseDetector is standalone (not wired into @AsyncTest). You declare
+ * the gatherer's shape up front with registerGatherer(name, hasCombiner, parallel), then
+ * call recordIntegrate(name, thread) from the integrator. Once the integrator is observed
+ * on more than one thread without a combiner, the detector fires.
+ */
+class RunningDistinctServiceTest {
+
+    private RunningDistinctService service;
+    private GathererConcurrencyMisuseDetector detector;
+
+    @BeforeEach
+    void setUp() {
+        service = new RunningDistinctService();
+        detector = new GathererConcurrencyMisuseDetector();
+    }
+
+    /** Run an integrator for {@code name} on two distinct threads (deterministic split). */
+    private void integrateOnTwoThreads(String name) throws InterruptedException {
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch go = new CountDownLatch(1);
+        Runnable r = () -> {
+            ready.countDown();
+            try { go.await(); } catch (InterruptedException e) { return; }
+            detector.recordIntegrate(name, Thread.currentThread());
+        };
+        Thread a = new Thread(r), b = new Thread(r);
+        a.start(); b.start();
+        ready.await();
+        go.countDown();
+        a.join(); b.join();
+    }
+
+    // -----------------------------------------------------------------------
+    // Part 1: safe variant — no shared mutable state; combiner present.
+    // -----------------------------------------------------------------------
+
+    @Test
+    void safeGatherer_withCombiner_isClean() throws Exception {
+        detector.registerGatherer("running-distinct", /*hasCombiner*/ true, /*parallel*/ true);
+        integrateOnTwoThreads("running-distinct");
+
+        // The service's safe variant produces correct distinct output.
+        List<String> out = service.distinctParallelSafe(List.of("a", "b", "a", "c", "b"));
+        assertEquals(3, out.size());
+
+        assertTrue(detector.analyze().getMissingCombinerIssues().isEmpty(),
+            "A combiner makes parallel use safe");
+    }
+
+    // -----------------------------------------------------------------------
+    // Part 2: buggy variant — stateful, no combiner, on a parallel stream.
+    // -----------------------------------------------------------------------
+
+    @Test
+    void statefulGatherer_noCombiner_onParallelStream_isDetected() throws Exception {
+        detector.registerGatherer("running-distinct", /*hasCombiner*/ false, /*parallel*/ true);
+        integrateOnTwoThreads("running-distinct");
+
+        var report = detector.analyze();
+        assertTrue(report.hasIssues());
+        assertFalse(report.getMissingCombinerIssues().isEmpty());
+        assertTrue(report.getMissingCombinerIssues().get(0).contains("combiner"));
+    }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -112,6 +112,15 @@ Real-world examples demonstrating common Java concurrency bugs that `@AsyncTest`
 | 106 | [Shared Deflater/Inflater](106-shared-deflater/) | `SharedDeflaterDetector` | A `java.util.zip.Deflater` shared across threads — stateful native zlib stream corrupts output or crashes on `end()` mid-stream | 🔴 Critical |
 | 107 | [This-Escape From Constructor](107-this-escape/) | `ThisEscapeDetector` | Constructor publishes `this` (registers a listener / starts a thread) before returning — other threads see a partially-constructed object | 🟡 High |
 | 108 | [ThreadLocalRandom Misuse](108-thread-local-random-misuse/) | `ThreadLocalRandomMisuseDetector` | A cached `ThreadLocalRandom.current()` reference used from other threads — defeats per-thread isolation, biases output | 🟡 High |
+| 114 | [StableValue Misuse](114-stable-value-misuse/) | `StableValueMisuseDetector` *(standalone, JDK 25/26)* | `StableValue` (JEP 502) read before set (`NoSuchElementException`) or set twice (lost update) | 🔴 Critical |
+| 115 | [StructuredTaskScope Misuse](115-structured-task-scope-misuse/) | `StructuredTaskScopeMisuseDetector` *(standalone, JDK 25/26)* | `StructuredTaskScope.open(Joiner)` (JEP 505) lifecycle broken — fork-after-join, result-before-join, owner-confinement, missing join | 🔴 Critical |
+| 116 | [Gatherer Parallel Misuse](116-gatherer-parallel-misuse/) | `GathererConcurrencyMisuseDetector` *(standalone, JDK 24+)* | Stateful `Gatherer` (JEP 485) on a parallel stream with no combiner — per-thread states can't merge, results lost | 🟠 High |
+
+> Examples 114–116 use **standalone** JDK 25/26 detectors — they are not part of the
+> `@AsyncTest` `detectAll` pipeline (that requires a `DetectorType` enum constant, and the
+> enum is a locked file). Each test instantiates the detector directly, records events, and
+> asserts on `analyze()`. They depend on the in-progress build, so install the parent to
+> `mavenLocal` first (`mvn -f ../../pom.xml install -DskipTests -Dlicense.mock.mode=true`).
 
 ## Phase 7: High-Level Concurrency Patterns (New!)
 
@@ -661,6 +670,59 @@ void testWorker() {
 ```
 
 **Fix**: Call `worker.setUncaughtExceptionHandler(handler)` before `start()`, or use a `ThreadFactory` that installs a handler on every created thread.
+
+---
+
+## JDK 25/26 Preview-Era Examples (Standalone Detectors)
+
+Examples **114–116** target concurrency features introduced or finalized in JDK 24–26.
+The detectors are standalone — instantiate, record events, call `analyze()` — because
+wiring one into the `@AsyncTest` pipeline requires a `DetectorType` enum constant and that
+enum is a locked file. Each detector is implemented against `String` keys + `Thread`, so it
+compiles and runs on the Java 21 baseline while modeling APIs that exist only on JDK 24/25/26.
+
+### 114 — StableValue Misuse (JEP 502)
+**What**: `StableValue<T>` is a deferred-immutable holder, settable at most once and then
+constant-folded by the JVM. Detects read-before-set (`NoSuchElementException`), double-set
+(lost update / `IllegalStateException`), and reentrant `orElseSet` suppliers.
+
+**Detect**:
+```java
+var d = new StableValueMisuseDetector();
+d.recordRead("CONFIG", Thread.currentThread());   // before any set → flagged
+d.recordSet("CONFIG", Thread.currentThread());
+d.recordSet("CONFIG", Thread.currentThread());    // double set → flagged
+assertTrue(d.analyze().hasIssues());
+```
+
+### 115 — StructuredTaskScope Misuse (JEP 505)
+**What**: The JDK 25 `StructuredTaskScope.open(Joiner)` API enforces
+`open → fork* → join → get* → close`. Detects fork-after-join, `Subtask.get()` before join,
+owner-confinement violations (`WrongThreadException`), and close-without-join.
+
+**Detect**:
+```java
+var d = new StructuredTaskScopeMisuseDetector();
+Thread owner = Thread.currentThread();
+d.recordScopeOpened("s", owner);
+d.recordFork("s", "a", owner);
+d.recordJoin("s", owner);
+d.recordFork("s", "late", owner);     // fork after join → flagged
+assertTrue(d.analyze().hasIssues());
+```
+
+### 116 — Gatherer Parallel Misuse (JEP 485)
+**What**: A stateful `Gatherer` on a parallel stream needs a combiner to merge per-thread
+states. Detects a stateful gatherer with no combiner running on more than one thread (lost
+results) and concurrent-integrator shared-state races.
+
+**Detect**:
+```java
+var d = new GathererConcurrencyMisuseDetector();
+d.registerGatherer("running", /*hasCombiner*/ false, /*parallel*/ true);
+// integrator: d.recordIntegrate("running", Thread.currentThread());
+assertTrue(d.analyze().hasIssues());
+```
 
 ---
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -122,5 +122,8 @@
         <module>111-lock-upgrade-deadlock</module>
         <module>112-try-lock-misuse</module>
         <module>113-completablefuture-blocking-callback</module>
+        <module>114-stable-value-misuse</module>
+        <module>115-structured-task-scope-misuse</module>
+        <module>116-gatherer-parallel-misuse</module>
     </modules>
 </project>

--- a/src/main/java/se/deversity/asynctest/diagnostics/GathererConcurrencyMisuseDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/GathererConcurrencyMisuseDetector.java
@@ -1,0 +1,251 @@
+package se.deversity.asynctest.diagnostics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import se.deversity.vibetags.annotations.AITestDriven;
+
+/**
+ * Detects unsafe use of {@code Stream.gather(Gatherer)} (JEP 485 — Stream
+ * Gatherers, finalized in JDK 24 and the standard intermediate-operation
+ * extension point in JDK 25/26) under parallel evaluation.
+ *
+ * <p>A {@code Gatherer} has four parts: an {@code initializer} (per-thread private
+ * state), an {@code integrator}, an optional {@code combiner}, and an optional
+ * {@code finisher}. On a <strong>parallel</strong> stream the framework splits the
+ * input, runs the integrator on independent state objects across worker threads,
+ * and then merges those states with the {@code combiner}. The contract is:
+ *
+ * <ul>
+ *   <li>If a gatherer keeps mutable state, it <em>must</em> supply a {@code combiner}
+ *       so the per-thread states can be merged. A {@code Gatherer.ofSequential(...)}
+ *       (or any gatherer built without a combiner) is forced to run sequentially.</li>
+ *   <li>The integrator must only touch the per-element state object it is handed —
+ *       never shared/captured mutable state — or parallel workers race on it.</li>
+ * </ul>
+ *
+ * <p>The dangerous combination is a gatherer whose integrator mutates state that is
+ * <em>shared</em> across the split (captured field, external collection, instance
+ * counter) while running on a parallel stream <em>without</em> a combiner. The
+ * result is a silent data race: lost updates, {@code ConcurrentModificationException},
+ * or non-deterministic output. This detector flags exactly that pattern.
+ *
+ * <p><strong>Issues detected:</strong>
+ * <ul>
+ *   <li><b>Stateful gatherer on a parallel stream without a combiner</b> — the
+ *       integrator was observed mutating state on more than one worker thread, but
+ *       the gatherer declared no combiner. Workers cannot merge → lost results.</li>
+ *   <li><b>Shared-state race</b> — the integrator of a single gatherer ran
+ *       concurrently on multiple threads against the same state key, indicating the
+ *       integrator captured shared mutable state instead of using its private
+ *       per-thread state.</li>
+ * </ul>
+ *
+ * <p><strong>Usage:</strong>
+ * <pre>{@code
+ * @AsyncTest(threads = 8)
+ * void testParallelGather() {
+ *     var detector = AsyncTestContext.gathererConcurrencyMisuseDetector();
+ *     // Describe the gatherer once, up front:
+ *     detector.registerGatherer("dedupRunning", false /* no combiner *​/, true /* parallel *​/);
+ *
+ *     list.parallelStream()
+ *         .gather(dedupRunning())   // integrator calls recordIntegrate(...) per element
+ *         .toList();
+ * }
+ * }</pre>
+ *
+ * @since 1.7.0
+ */
+@AITestDriven(
+    framework = {AITestDriven.Framework.JUNIT_5},
+    coverageGoal = 80,
+    testLocation = "src/test/java/se/deversity/asynctest/diagnostics/GathererConcurrencyMisuseDetectorTest.java"
+)
+public class GathererConcurrencyMisuseDetector {
+
+    private static final class GathererInfo {
+        final boolean hasCombiner;
+        final boolean parallel;
+        final Set<Long> integratingThreadIds = ConcurrentHashMap.newKeySet();
+        final AtomicInteger integrations = new AtomicInteger(0);
+
+        GathererInfo(boolean hasCombiner, boolean parallel) {
+            this.hasCombiner = hasCombiner;
+            this.parallel = parallel;
+        }
+    }
+
+    private final Map<String, GathererInfo> gatherers = new ConcurrentHashMap<>();
+
+    private final List<String> missingCombinerReports = Collections.synchronizedList(new ArrayList<>());
+    private final List<String> sharedStateReports     = Collections.synchronizedList(new ArrayList<>());
+
+    private final AtomicInteger totalIntegrations = new AtomicInteger(0);
+
+    /**
+     * Declare a gatherer's shape before the stream runs.
+     *
+     * @param name        a descriptive name for the gatherer (e.g. the factory method)
+     * @param hasCombiner whether the gatherer supplies a combiner (parallel-safe merge)
+     * @param parallel    whether it is used on a parallel stream
+     */
+    public void registerGatherer(String name, boolean hasCombiner, boolean parallel) {
+        if (name == null) return;
+        gatherers.put(name, new GathererInfo(hasCombiner, parallel));
+    }
+
+    /**
+     * Record one integrator invocation for the given gatherer on the current thread.
+     * When the integrator is seen running on more than one thread, we can confirm the
+     * stream actually parallelized — and judge whether that was safe.
+     *
+     * @param name   the gatherer's registered name
+     * @param thread the thread running the integrator
+     */
+    public void recordIntegrate(String name, Thread thread) {
+        if (name == null || thread == null) return;
+        totalIntegrations.incrementAndGet();
+        GathererInfo info = gatherers.get(name);
+        if (info == null) return;
+
+        info.integrations.incrementAndGet();
+        boolean firstFromThisThread = info.integratingThreadIds.add(thread.threadId());
+
+        // Only meaningful once we have evidence of multi-thread execution.
+        if (firstFromThisThread && info.integratingThreadIds.size() == 2) {
+            if (!info.hasCombiner) {
+                missingCombinerReports.add(
+                    "Gatherer '" + name + "': integrator ran on multiple threads but the gatherer "
+                    + "declares no combiner. On a parallel stream the per-thread states cannot be "
+                    + "merged — results are lost or non-deterministic. Add a combiner, or build it "
+                    + "with Gatherer.ofSequential(...) to force sequential evaluation."
+                );
+            }
+            if (info.parallel) {
+                sharedStateReports.add(
+                    "Gatherer '" + name + "': integrator observed on " + info.integratingThreadIds.size()
+                    + " threads concurrently. Ensure it mutates only its private per-thread state "
+                    + "(from the initializer) and never captured/shared mutable state, which would "
+                    + "race across the split."
+                );
+            }
+        }
+    }
+
+    /**
+     * Analyze all recorded gatherer events for unsafe parallel usage.
+     *
+     * @return a report describing detected issues
+     */
+    public GathererConcurrencyMisuseReport analyze() {
+        return new GathererConcurrencyMisuseReport(
+            new ArrayList<>(missingCombinerReports),
+            new ArrayList<>(sharedStateReports),
+            gatherers.size(),
+            totalIntegrations.get()
+        );
+    }
+
+    /**
+     * Report of Gatherer concurrency-misuse analysis.
+     */
+    public static class GathererConcurrencyMisuseReport {
+        private final List<String> missingCombinerIssues;
+        private final List<String> sharedStateIssues;
+        private final int totalGatherers;
+        private final int totalIntegrations;
+
+        GathererConcurrencyMisuseReport(
+                List<String> missingCombinerIssues,
+                List<String> sharedStateIssues,
+                int totalGatherers,
+                int totalIntegrations) {
+            this.missingCombinerIssues = missingCombinerIssues;
+            this.sharedStateIssues = sharedStateIssues;
+            this.totalGatherers = totalGatherers;
+            this.totalIntegrations = totalIntegrations;
+        }
+
+        /** @return true if any unsafe parallel-gatherer usage was detected */
+        public boolean hasIssues() {
+            return !missingCombinerIssues.isEmpty() || !sharedStateIssues.isEmpty();
+        }
+
+        public List<String> getMissingCombinerIssues() { return Collections.unmodifiableList(missingCombinerIssues); }
+        public List<String> getSharedStateIssues()     { return Collections.unmodifiableList(sharedStateIssues); }
+        public int          getTotalGatherers()        { return totalGatherers; }
+        public int          getTotalIntegrations()     { return totalIntegrations; }
+
+        @Override
+        public String toString() {
+            if (!hasIssues()) {
+                return "GathererConcurrencyMisuseReport: No unsafe parallel-gatherer usage detected";
+            }
+
+            StringBuilder sb = new StringBuilder();
+
+            if (!missingCombinerIssues.isEmpty()) {
+                sb.append(IssueSeverity.HIGH.format())
+                  .append(": Stateful gatherer on a parallel stream without a combiner (lost results)\n");
+            } else {
+                sb.append(IssueSeverity.MEDIUM.format())
+                  .append(": Gatherer integrator ran concurrently — verify state confinement\n");
+            }
+
+            sb.append("  Gatherers=").append(totalGatherers)
+              .append(", Integrations=").append(totalIntegrations).append("\n");
+
+            appendSection(sb, "Missing combiner on parallel stream (lost results)", missingCombinerIssues);
+            appendSection(sb, "Concurrent integrator — confirm per-thread state confinement", sharedStateIssues);
+
+            sb.append("\n\n").append("=".repeat(60));
+            sb.append("\n").append(getLearningContent());
+            sb.append("=".repeat(60));
+
+            return sb.toString();
+        }
+
+        private static void appendSection(StringBuilder sb, String title, List<String> items) {
+            if (items.isEmpty()) return;
+            sb.append("\n  ").append(title).append(":\n");
+            for (String item : items) {
+                sb.append("    - ").append(item).append("\n");
+            }
+        }
+
+        private static String getLearningContent() {
+            return """
+                📚 LEARNING: Stream Gatherers (Java 24+, JEP 485)
+
+                Stream.gather(Gatherer) is the extension point for custom intermediate
+                operations. A Gatherer = initializer + integrator + (combiner) + (finisher).
+
+                On a PARALLEL stream the runtime:
+                  1. splits the input,
+                  2. runs the integrator on independent state per worker thread,
+                  3. merges those states with the COMBINER.
+
+                Correct usage:
+                  // Stateful + parallel-safe → MUST provide a combiner:
+                  Gatherer.of(initializer, integrator, combiner, finisher);
+
+                  // Stateful but no safe merge → force sequential:
+                  Gatherer.ofSequential(initializer, integrator, finisher);
+
+                Common mistakes:
+                  ✗ Stateful gatherer with no combiner on a parallel stream → states can't
+                    merge; results are dropped or non-deterministic
+                  ✗ Integrator mutating captured/shared state instead of its private state
+                    object → data race across the split (lost updates, CME)
+
+                Rule of thumb: keep all mutation inside the per-thread state from the
+                initializer, and supply a combiner whenever the gatherer can go parallel.
+                """;
+        }
+    }
+}

--- a/src/main/java/se/deversity/asynctest/diagnostics/StableValueMisuseDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/StableValueMisuseDetector.java
@@ -1,0 +1,331 @@
+package se.deversity.asynctest.diagnostics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import se.deversity.vibetags.annotations.AITestDriven;
+
+/**
+ * Detects misuse of Java 25+ {@code StableValue} (JEP 502 — Stable Values,
+ * Preview in JDK 25, continuing in JDK 26).
+ *
+ * <p>{@code StableValue<T>} is a <em>deferred-immutable</em> holder: it is
+ * unset at construction and may be set <strong>at most once</strong>. Once set,
+ * its content is treated by the JVM as a true constant (it can be constant-folded
+ * like a {@code final} field), while still allowing the assignment to happen
+ * lazily. This makes it the modern, thread-safe replacement for the
+ * double-checked-locking and holder-class lazy-initialization idioms.
+ *
+ * <p>The safety guarantees only hold if the access pattern respects the
+ * at-most-once contract. This detector flags the patterns that break it:
+ *
+ * <p><strong>Issues detected:</strong>
+ * <ul>
+ *   <li><b>Read before set</b> — {@code orElseThrow()} / {@code get()} invoked
+ *       before any value has been set; this throws {@code NoSuchElementException}
+ *       at runtime. Under concurrency this is a publication race: a reader can
+ *       observe the holder before the writer's {@code trySet} completes.</li>
+ *   <li><b>Double set</b> — a second {@code setOrThrow(...)} (or a {@code trySet}
+ *       with a conflicting value) after the holder is already set. {@code setOrThrow}
+ *       throws {@code IllegalStateException}; {@code trySet} silently drops the
+ *       second value — a lost update when callers assume their write won.</li>
+ *   <li><b>Reentrant computation</b> — the supplier passed to {@code orElseSet(...)}
+ *       reads the <em>same</em> {@code StableValue} (directly or transitively) while
+ *       it is still computing. This is a self-deadlock / {@code IllegalStateException}
+ *       on the JDK implementation and an infinite recursion in hand-rolled holders.</li>
+ *   <li><b>Set contention</b> — many distinct threads race to set the same holder.
+ *       Correct but wasteful: all-but-one supplier invocation is discarded, so a
+ *       costly supplier is computed N times for one stored result (design smell).</li>
+ * </ul>
+ *
+ * <p><strong>Usage:</strong>
+ * <pre>{@code
+ * private static final StableValue<Config> CONFIG = StableValue.of();
+ *
+ * @AsyncTest(threads = 16)
+ * void testLazyConfig() {
+ *     var detector = AsyncTestContext.stableValueMisuseDetector();
+ *     String name = "CONFIG";
+ *
+ *     detector.recordSupplierStart(name, Thread.currentThread());
+ *     Config c = CONFIG.orElseSet(() -> loadConfig()); // at-most-once
+ *     detector.recordSupplierEnd(name, Thread.currentThread());
+ *
+ *     detector.recordRead(name, Thread.currentThread());
+ *     use(c);
+ * }
+ * }</pre>
+ *
+ * @since 1.7.0
+ */
+@AITestDriven(
+    framework = {AITestDriven.Framework.JUNIT_5},
+    coverageGoal = 80,
+    testLocation = "src/test/java/se/deversity/asynctest/diagnostics/StableValueMisuseDetectorTest.java"
+)
+public class StableValueMisuseDetector {
+
+    /** Above this many distinct threads racing one holder, we warn about wasted supplier work. */
+    private static final int SET_CONTENTION_THRESHOLD = 3;
+
+    private static final class State {
+        final AtomicBoolean set = new AtomicBoolean(false);
+        final AtomicInteger setAttempts = new AtomicInteger(0);
+        final Set<Long> settingThreadIds = ConcurrentHashMap.newKeySet();
+        final AtomicBoolean contentionReported = new AtomicBoolean(false);
+    }
+
+    // Per-holder state, keyed by the caller-supplied descriptive name.
+    private final Map<String, State> states = new ConcurrentHashMap<>();
+
+    // Per-thread set of holder names whose orElseSet supplier is currently running (reentrancy).
+    private final Map<Long, Set<String>> activeSuppliers = new ConcurrentHashMap<>();
+
+    private final List<String> readBeforeSetReports  = Collections.synchronizedList(new ArrayList<>());
+    private final List<String> doubleSetReports       = Collections.synchronizedList(new ArrayList<>());
+    private final List<String> reentrantReports       = Collections.synchronizedList(new ArrayList<>());
+    private final List<String> contentionWarnings     = Collections.synchronizedList(new ArrayList<>());
+
+    private final AtomicInteger totalReads = new AtomicInteger(0);
+    private final AtomicInteger totalSets  = new AtomicInteger(0);
+
+    private State stateFor(String name) {
+        State s = states.get(name);
+        if (s == null) {
+            s = states.computeIfAbsent(name, k -> new State());
+        }
+        return s;
+    }
+
+    /**
+     * Record a value-set attempt ({@code trySet} / {@code setOrThrow}) on the holder.
+     * A second attempt after the holder is already set is reported as a double-set.
+     *
+     * @param name   a descriptive name for the StableValue (e.g. field name)
+     * @param thread the current thread
+     */
+    public void recordSet(String name, Thread thread) {
+        if (name == null || thread == null) return;
+        totalSets.incrementAndGet();
+        State s = stateFor(name);
+        s.settingThreadIds.add(thread.threadId());
+        s.setAttempts.incrementAndGet();
+
+        boolean wasAlreadySet = !s.set.compareAndSet(false, true);
+        if (wasAlreadySet) {
+            doubleSetReports.add(
+                "Thread " + thread.getName() + " (id=" + thread.threadId() + "): "
+                + "StableValue '" + name + "' set again after it was already set. "
+                + "setOrThrow() throws IllegalStateException here; trySet() silently drops "
+                + "this value — a lost update if this writer assumed it won."
+            );
+        }
+
+        // Record once per holder, the first time the distinct-thread count crosses
+        // the threshold. The one-shot flag avoids both duplicates and the missed-edge
+        // race of comparing size() to an exact value under concurrent adds.
+        if (s.settingThreadIds.size() >= SET_CONTENTION_THRESHOLD
+                && s.contentionReported.compareAndSet(false, true)) {
+            contentionWarnings.add(
+                "StableValue '" + name + "': " + s.settingThreadIds.size()
+                + " distinct threads raced to set it. Only one value is stored; the "
+                + "supplier work of the losers is discarded. Prefer a single orElseSet(...) "
+                + "with an idempotent, side-effect-free supplier."
+            );
+        }
+    }
+
+    /**
+     * Record a read ({@code orElseThrow()} / {@code get()}) on the holder.
+     * A read before any set is reported as a read-before-set (NoSuchElementException risk).
+     *
+     * @param name   a descriptive name for the StableValue
+     * @param thread the current thread
+     */
+    public void recordRead(String name, Thread thread) {
+        if (name == null || thread == null) return;
+        totalReads.incrementAndGet();
+        State s = stateFor(name);
+        if (!s.set.get()) {
+            readBeforeSetReports.add(
+                "Thread " + thread.getName() + " (id=" + thread.threadId() + "): "
+                + "StableValue '" + name + "' read via orElseThrow()/get() before it was set — "
+                + "this throws NoSuchElementException. Use orElseSet(supplier) for lazy init, "
+                + "or guard the read after confirming the value is present."
+            );
+        }
+    }
+
+    /**
+     * Record the start of an {@code orElseSet(supplier)} computation. If the same
+     * holder's supplier is already running on this thread, the supplier is reading
+     * the value it is meant to produce (reentrant computation).
+     *
+     * @param name   a descriptive name for the StableValue
+     * @param thread the current thread
+     */
+    public void recordSupplierStart(String name, Thread thread) {
+        if (name == null || thread == null) return;
+        long tid = thread.threadId();
+        Set<String> running = activeSuppliers.computeIfAbsent(tid, k -> ConcurrentHashMap.newKeySet());
+        if (!running.add(name)) {
+            reentrantReports.add(
+                "Thread " + thread.getName() + " (id=" + tid + "): "
+                + "StableValue '" + name + "' orElseSet() supplier re-entered the same holder "
+                + "while it was still computing. The JDK throws IllegalStateException to break "
+                + "the cycle; a hand-rolled holder would recurse infinitely. Remove the "
+                + "self-reference from the supplier."
+            );
+        }
+    }
+
+    /**
+     * Record the successful completion of an {@code orElseSet(supplier)} computation.
+     * Marks the holder as set.
+     *
+     * @param name   a descriptive name for the StableValue
+     * @param thread the current thread
+     */
+    public void recordSupplierEnd(String name, Thread thread) {
+        if (name == null || thread == null) return;
+        long tid = thread.threadId();
+        Set<String> running = activeSuppliers.get(tid);
+        if (running != null) {
+            running.remove(name);
+        }
+        State s = stateFor(name);
+        s.settingThreadIds.add(tid);
+        s.set.set(true);
+    }
+
+    /**
+     * Analyze all recorded StableValue events for misuse patterns.
+     *
+     * @return a report describing detected issues
+     */
+    public StableValueMisuseReport analyze() {
+        return new StableValueMisuseReport(
+            new ArrayList<>(readBeforeSetReports),
+            new ArrayList<>(doubleSetReports),
+            new ArrayList<>(reentrantReports),
+            new ArrayList<>(contentionWarnings),
+            totalReads.get(),
+            totalSets.get()
+        );
+    }
+
+    /**
+     * Report of StableValue misuse analysis.
+     */
+    public static class StableValueMisuseReport {
+        private final List<String> readBeforeSetIssues;
+        private final List<String> doubleSetIssues;
+        private final List<String> reentrantIssues;
+        private final List<String> contentionWarnings;
+        private final int totalReads;
+        private final int totalSets;
+
+        StableValueMisuseReport(
+                List<String> readBeforeSetIssues,
+                List<String> doubleSetIssues,
+                List<String> reentrantIssues,
+                List<String> contentionWarnings,
+                int totalReads,
+                int totalSets) {
+            this.readBeforeSetIssues = readBeforeSetIssues;
+            this.doubleSetIssues = doubleSetIssues;
+            this.reentrantIssues = reentrantIssues;
+            this.contentionWarnings = contentionWarnings;
+            this.totalReads = totalReads;
+            this.totalSets = totalSets;
+        }
+
+        /** @return true if any correctness-affecting StableValue misuse was detected */
+        public boolean hasIssues() {
+            return !readBeforeSetIssues.isEmpty()
+                || !doubleSetIssues.isEmpty()
+                || !reentrantIssues.isEmpty();
+        }
+
+        public List<String> getReadBeforeSetIssues() { return Collections.unmodifiableList(readBeforeSetIssues); }
+        public List<String> getDoubleSetIssues()      { return Collections.unmodifiableList(doubleSetIssues); }
+        public List<String> getReentrantIssues()      { return Collections.unmodifiableList(reentrantIssues); }
+        public List<String> getContentionWarnings()   { return Collections.unmodifiableList(contentionWarnings); }
+        public int          getTotalReads()           { return totalReads; }
+        public int          getTotalSets()            { return totalSets; }
+
+        @Override
+        public String toString() {
+            if (!hasIssues() && contentionWarnings.isEmpty()) {
+                return "StableValueMisuseReport: No StableValue misuse detected";
+            }
+
+            StringBuilder sb = new StringBuilder();
+
+            if (!reentrantIssues.isEmpty() || !readBeforeSetIssues.isEmpty()) {
+                sb.append(IssueSeverity.CRITICAL.format())
+                  .append(": StableValue accessed before/while being set (will throw at runtime)\n");
+            } else if (!doubleSetIssues.isEmpty()) {
+                sb.append(IssueSeverity.HIGH.format())
+                  .append(": StableValue set more than once (lost update / IllegalStateException)\n");
+            } else {
+                sb.append(IssueSeverity.LOW.format())
+                  .append(": StableValue usage warnings\n");
+            }
+
+            sb.append("  Reads=").append(totalReads)
+              .append(", Sets=").append(totalSets).append("\n");
+
+            appendSection(sb, "Read before set (NoSuchElementException risk)", readBeforeSetIssues);
+            appendSection(sb, "Double set (lost update / IllegalStateException)", doubleSetIssues);
+            appendSection(sb, "Reentrant orElseSet() computation", reentrantIssues);
+            appendSection(sb, "Set contention (wasted supplier work)", contentionWarnings);
+
+            sb.append("\n\n").append("=".repeat(60));
+            sb.append("\n").append(getLearningContent());
+            sb.append("=".repeat(60));
+
+            return sb.toString();
+        }
+
+        private static void appendSection(StringBuilder sb, String title, List<String> items) {
+            if (items.isEmpty()) return;
+            sb.append("\n  ").append(title).append(":\n");
+            for (String item : items) {
+                sb.append("    - ").append(item).append("\n");
+            }
+        }
+
+        private static String getLearningContent() {
+            return """
+                📚 LEARNING: StableValue (Java 25+, JEP 502)
+
+                StableValue<T> is a deferred-immutable holder: unset at first, settable
+                at most once, then treated as a true constant by the JVM. It replaces the
+                double-checked-locking and holder-class idioms for thread-safe lazy init.
+
+                Correct usage:
+                  static final StableValue<Config> CONFIG = StableValue.of();
+
+                  // Lazy, at-most-once, thread-safe:
+                  Config c = CONFIG.orElseSet(() -> loadConfig());
+
+                Common mistakes:
+                  ✗ orElseThrow()/get() before the value is set → NoSuchElementException
+                  ✗ setOrThrow() twice → IllegalStateException (or trySet drops the 2nd value)
+                  ✗ orElseSet supplier that reads the same StableValue → reentrant deadlock
+                  ✗ Many threads each computing a costly supplier to set one holder (only
+                    one result is kept — make the supplier idempotent and side-effect-free)
+
+                Rule of thumb:
+                  • Set exactly once, via orElseSet(supplier), with a pure supplier.
+                  • Never read before the set is guaranteed to have happened-before the read.
+                """;
+        }
+    }
+}

--- a/src/main/java/se/deversity/asynctest/diagnostics/StructuredTaskScopeMisuseDetector.java
+++ b/src/main/java/se/deversity/asynctest/diagnostics/StructuredTaskScopeMisuseDetector.java
@@ -1,0 +1,318 @@
+package se.deversity.asynctest.diagnostics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import se.deversity.vibetags.annotations.AITestDriven;
+
+/**
+ * Detects misuse of the Java 25 {@code StructuredTaskScope} API (JEP 505 —
+ * Structured Concurrency, fifth preview in JDK 25, on track to finalize in
+ * JDK 26).
+ *
+ * <p>The JDK 25 API reshapes structured concurrency around a single factory and
+ * a pluggable {@code Joiner}:
+ * <pre>{@code
+ * try (var scope = StructuredTaskScope.open(Joiner.<String>allSuccessfulOrThrow())) {
+ *     Subtask<String> a = scope.fork(() -> fetchA());
+ *     Subtask<String> b = scope.fork(() -> fetchB());
+ *     scope.join();                 // wait for the policy to be satisfied
+ *     return combine(a.get(), b.get());
+ * }
+ * }</pre>
+ *
+ * <p>The structure enforces a strict lifecycle. Breaking it does not merely
+ * produce a bad result — it throws, leaks subtasks, or silently returns a value
+ * read from an incomplete subtask. This detector models the lifecycle as a small
+ * state machine per scope and flags the transitions that the runtime rejects:
+ *
+ * <p><strong>Issues detected:</strong>
+ * <ul>
+ *   <li><b>Fork after join</b> — {@code fork(...)} called after {@code join()} on
+ *       the same scope. The runtime throws {@code IllegalStateException}; the scope
+ *       is no longer accepting work.</li>
+ *   <li><b>Result before join</b> — {@code Subtask.get()} called before {@code join()}
+ *       completes, or while the subtask state is not {@code SUCCESS}. Throws
+ *       {@code IllegalStateException} and, if it didn't, would read an
+ *       unpublished / partial result.</li>
+ *   <li><b>Owner-confinement violation</b> — {@code fork()} / {@code join()} invoked
+ *       from a thread other than the one that opened the scope. The runtime throws
+ *       {@code WrongThreadException} (or {@code StructureViolationException}); a scope
+ *       is confined to its owning thread.</li>
+ *   <li><b>Missing join</b> — the scope is closed without {@code join()} having been
+ *       called after at least one {@code fork()}. Closing cancels the still-running
+ *       subtasks; their work (and any side effects) is abandoned.</li>
+ * </ul>
+ *
+ * <p><strong>Usage:</strong>
+ * <pre>{@code
+ * @AsyncTest(threads = 8, useVirtualThreads = true)
+ * void testStructuredFanOut() {
+ *     var detector = AsyncTestContext.structuredTaskScopeMisuseDetector();
+ *     String scopeId = "fanout";
+ *     Thread owner = Thread.currentThread();
+ *
+ *     detector.recordScopeOpened(scopeId, owner);
+ *     detector.recordFork(scopeId, "a", owner);
+ *     detector.recordJoin(scopeId, owner);
+ *     detector.recordResultRead(scopeId, "a", owner);
+ *     detector.recordScopeClosed(scopeId, owner);
+ * }
+ * }</pre>
+ *
+ * @since 1.7.0
+ */
+@AITestDriven(
+    framework = {AITestDriven.Framework.JUNIT_5},
+    coverageGoal = 80,
+    testLocation = "src/test/java/se/deversity/asynctest/diagnostics/StructuredTaskScopeMisuseDetectorTest.java"
+)
+public class StructuredTaskScopeMisuseDetector {
+
+    private static final class ScopeState {
+        final long ownerThreadId;
+        final String ownerThreadName;
+        volatile boolean joined = false;
+        final AtomicInteger forkCount = new AtomicInteger(0);
+
+        ScopeState(long ownerThreadId, String ownerThreadName) {
+            this.ownerThreadId = ownerThreadId;
+            this.ownerThreadName = ownerThreadName;
+        }
+    }
+
+    // Per-scope lifecycle state, keyed by a caller-supplied scope id.
+    private final Map<String, ScopeState> scopes = new ConcurrentHashMap<>();
+
+    private final List<String> forkAfterJoinReports   = Collections.synchronizedList(new ArrayList<>());
+    private final List<String> resultBeforeJoinReports = Collections.synchronizedList(new ArrayList<>());
+    private final List<String> confinementReports      = Collections.synchronizedList(new ArrayList<>());
+    private final List<String> missingJoinReports      = Collections.synchronizedList(new ArrayList<>());
+
+    private final AtomicInteger totalForks = new AtomicInteger(0);
+    private final AtomicInteger totalScopes = new AtomicInteger(0);
+
+    /**
+     * Record that a {@code StructuredTaskScope.open(...)} returned a new scope,
+     * confined to the opening (owner) thread.
+     */
+    public void recordScopeOpened(String scopeId, Thread owner) {
+        if (scopeId == null || owner == null) return;
+        totalScopes.incrementAndGet();
+        scopes.put(scopeId, new ScopeState(owner.threadId(), owner.getName()));
+    }
+
+    /**
+     * Record a {@code scope.fork(task)} call. Flags fork-after-join and
+     * owner-confinement violations.
+     */
+    public void recordFork(String scopeId, String subtaskId, Thread thread) {
+        if (scopeId == null || subtaskId == null || thread == null) return;
+        totalForks.incrementAndGet();
+        ScopeState s = scopes.get(scopeId);
+        if (s == null) return;
+
+        if (thread.threadId() != s.ownerThreadId) {
+            confinementReports.add(
+                "Thread " + thread.getName() + " (id=" + thread.threadId() + "): "
+                + "fork() on scope '" + scopeId + "' from a non-owner thread (owner='"
+                + s.ownerThreadName + "', id=" + s.ownerThreadId + "). A StructuredTaskScope "
+                + "is confined to its owner; this throws WrongThreadException."
+            );
+        }
+        if (s.joined) {
+            forkAfterJoinReports.add(
+                "Thread " + thread.getName() + " (id=" + thread.threadId() + "): "
+                + "fork() of subtask '" + subtaskId + "' on scope '" + scopeId + "' after join() "
+                + "had already returned. The scope no longer accepts work; this throws "
+                + "IllegalStateException."
+            );
+        }
+        s.forkCount.incrementAndGet();
+    }
+
+    /**
+     * Record a {@code scope.join()} call. Flags owner-confinement violations and
+     * marks the scope as joined.
+     */
+    public void recordJoin(String scopeId, Thread thread) {
+        if (scopeId == null || thread == null) return;
+        ScopeState s = scopes.get(scopeId);
+        if (s == null) return;
+
+        if (thread.threadId() != s.ownerThreadId) {
+            confinementReports.add(
+                "Thread " + thread.getName() + " (id=" + thread.threadId() + "): "
+                + "join() on scope '" + scopeId + "' from a non-owner thread (owner='"
+                + s.ownerThreadName + "', id=" + s.ownerThreadId + "). join() must be called "
+                + "by the owning thread; this throws WrongThreadException."
+            );
+        }
+        s.joined = true;
+    }
+
+    /**
+     * Record a {@code Subtask.get()} call. Flags reads that happen before the
+     * scope has been joined.
+     */
+    public void recordResultRead(String scopeId, String subtaskId, Thread thread) {
+        if (scopeId == null || subtaskId == null || thread == null) return;
+        ScopeState s = scopes.get(scopeId);
+        if (s == null) return;
+
+        if (!s.joined) {
+            resultBeforeJoinReports.add(
+                "Thread " + thread.getName() + " (id=" + thread.threadId() + "): "
+                + "Subtask.get() for '" + subtaskId + "' on scope '" + scopeId + "' before join() "
+                + "completed. The subtask may not have finished; this throws IllegalStateException "
+                + "rather than returning a partial result."
+            );
+        }
+    }
+
+    /**
+     * Record that the scope was closed (the try-with-resources block ended).
+     * Flags a scope that forked subtasks but was never joined.
+     */
+    public void recordScopeClosed(String scopeId, Thread thread) {
+        if (scopeId == null || thread == null) return;
+        ScopeState s = scopes.get(scopeId);
+        if (s == null) return;
+
+        if (s.forkCount.get() > 0 && !s.joined) {
+            missingJoinReports.add(
+                "Scope '" + scopeId + "' (owner='" + s.ownerThreadName + "') was closed after "
+                + s.forkCount.get() + " fork(s) without ever calling join(). Closing cancels the "
+                + "still-running subtasks and discards their work — call join() before leaving the "
+                + "try-with-resources block."
+            );
+        }
+    }
+
+    /**
+     * Analyze all recorded StructuredTaskScope events for misuse patterns.
+     *
+     * @return a report describing detected issues
+     */
+    public StructuredTaskScopeMisuseReport analyze() {
+        return new StructuredTaskScopeMisuseReport(
+            new ArrayList<>(forkAfterJoinReports),
+            new ArrayList<>(resultBeforeJoinReports),
+            new ArrayList<>(confinementReports),
+            new ArrayList<>(missingJoinReports),
+            totalScopes.get(),
+            totalForks.get()
+        );
+    }
+
+    /**
+     * Report of StructuredTaskScope misuse analysis.
+     */
+    public static class StructuredTaskScopeMisuseReport {
+        private final List<String> forkAfterJoinIssues;
+        private final List<String> resultBeforeJoinIssues;
+        private final List<String> confinementIssues;
+        private final List<String> missingJoinIssues;
+        private final int totalScopes;
+        private final int totalForks;
+
+        StructuredTaskScopeMisuseReport(
+                List<String> forkAfterJoinIssues,
+                List<String> resultBeforeJoinIssues,
+                List<String> confinementIssues,
+                List<String> missingJoinIssues,
+                int totalScopes,
+                int totalForks) {
+            this.forkAfterJoinIssues = forkAfterJoinIssues;
+            this.resultBeforeJoinIssues = resultBeforeJoinIssues;
+            this.confinementIssues = confinementIssues;
+            this.missingJoinIssues = missingJoinIssues;
+            this.totalScopes = totalScopes;
+            this.totalForks = totalForks;
+        }
+
+        /** @return true if any StructuredTaskScope misuse was detected */
+        public boolean hasIssues() {
+            return !forkAfterJoinIssues.isEmpty()
+                || !resultBeforeJoinIssues.isEmpty()
+                || !confinementIssues.isEmpty()
+                || !missingJoinIssues.isEmpty();
+        }
+
+        public List<String> getForkAfterJoinIssues()    { return Collections.unmodifiableList(forkAfterJoinIssues); }
+        public List<String> getResultBeforeJoinIssues() { return Collections.unmodifiableList(resultBeforeJoinIssues); }
+        public List<String> getConfinementIssues()      { return Collections.unmodifiableList(confinementIssues); }
+        public List<String> getMissingJoinIssues()      { return Collections.unmodifiableList(missingJoinIssues); }
+        public int          getTotalScopes()            { return totalScopes; }
+        public int          getTotalForks()             { return totalForks; }
+
+        @Override
+        public String toString() {
+            if (!hasIssues()) {
+                return "StructuredTaskScopeMisuseReport: No StructuredTaskScope misuse detected";
+            }
+
+            StringBuilder sb = new StringBuilder();
+
+            if (!confinementIssues.isEmpty()
+                || !forkAfterJoinIssues.isEmpty()
+                || !resultBeforeJoinIssues.isEmpty()) {
+                sb.append(IssueSeverity.CRITICAL.format())
+                  .append(": StructuredTaskScope lifecycle violated (will throw at runtime)\n");
+            } else {
+                sb.append(IssueSeverity.HIGH.format())
+                  .append(": StructuredTaskScope subtasks abandoned (missing join)\n");
+            }
+
+            sb.append("  Scopes=").append(totalScopes)
+              .append(", Forks=").append(totalForks).append("\n");
+
+            appendSection(sb, "Fork after join (IllegalStateException)", forkAfterJoinIssues);
+            appendSection(sb, "Subtask.get() before join (IllegalStateException)", resultBeforeJoinIssues);
+            appendSection(sb, "Owner-confinement violation (WrongThreadException)", confinementIssues);
+            appendSection(sb, "Scope closed without join (subtasks cancelled)", missingJoinIssues);
+
+            sb.append("\n\n").append("=".repeat(60));
+            sb.append("\n").append(getLearningContent());
+            sb.append("=".repeat(60));
+
+            return sb.toString();
+        }
+
+        private static void appendSection(StringBuilder sb, String title, List<String> items) {
+            if (items.isEmpty()) return;
+            sb.append("\n  ").append(title).append(":\n");
+            for (String item : items) {
+                sb.append("    - ").append(item).append("\n");
+            }
+        }
+
+        private static String getLearningContent() {
+            return """
+                📚 LEARNING: StructuredTaskScope (Java 25, JEP 505)
+
+                Structured concurrency ties the lifetime of concurrent subtasks to a
+                lexical scope, so a fan-out cannot outlive the method that started it.
+
+                Correct usage:
+                  try (var scope = StructuredTaskScope.open(Joiner.<T>allSuccessfulOrThrow())) {
+                      Subtask<T> a = scope.fork(() -> taskA());
+                      Subtask<T> b = scope.fork(() -> taskB());
+                      scope.join();              // ← wait first
+                      return combine(a.get(), b.get());  // ← then read results
+                  }
+
+                Lifecycle rules (all enforced by the runtime):
+                  ✗ fork() after join()        → IllegalStateException
+                  ✗ Subtask.get() before join() → IllegalStateException (partial result)
+                  ✗ fork()/join() off-owner    → WrongThreadException (scope is confined)
+                  ✗ close() without join()     → running subtasks are cancelled, work lost
+
+                Order is always: open → fork* → join → get* → close (try-with-resources).
+                """;
+        }
+    }
+}

--- a/src/test/java/se/deversity/asynctest/diagnostics/GathererConcurrencyMisuseDetectorTest.java
+++ b/src/test/java/se/deversity/asynctest/diagnostics/GathererConcurrencyMisuseDetectorTest.java
@@ -1,0 +1,125 @@
+package se.deversity.asynctest.diagnostics;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link GathererConcurrencyMisuseDetector}.
+ */
+class GathererConcurrencyMisuseDetectorTest {
+
+    private GathererConcurrencyMisuseDetector detector;
+
+    @BeforeEach
+    void setUp() {
+        detector = new GathererConcurrencyMisuseDetector();
+    }
+
+    /** Run an integrator for {@code name} on two distinct platform threads. */
+    private void integrateOnTwoThreads(String name) throws InterruptedException {
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch go = new CountDownLatch(1);
+        Runnable r = () -> {
+            ready.countDown();
+            try { go.await(); } catch (InterruptedException ignored) { return; }
+            detector.recordIntegrate(name, Thread.currentThread());
+        };
+        Thread a = new Thread(r), b = new Thread(r);
+        a.start(); b.start();
+        ready.await();
+        go.countDown();
+        a.join(); b.join();
+    }
+
+    // ---- Happy path ----
+
+    @Test
+    void noIssues_sequentialSingleThread() {
+        detector.registerGatherer("g", false, false);
+        Thread t = Thread.currentThread();
+        detector.recordIntegrate("g", t);
+        detector.recordIntegrate("g", t);
+
+        var report = detector.analyze();
+        assertFalse(report.hasIssues(), "Single-thread integration is safe: " + report);
+        assertEquals(2, report.getTotalIntegrations());
+    }
+
+    @Test
+    void noIssues_parallelWithCombiner() throws Exception {
+        detector.registerGatherer("g", true /* has combiner */, true);
+        integrateOnTwoThreads("g");
+
+        var report = detector.analyze();
+        assertTrue(report.getMissingCombinerIssues().isEmpty(),
+            "A combiner makes parallel use safe: " + report);
+    }
+
+    // ---- Missing combiner ----
+
+    @Test
+    void detectsMissingCombiner_whenParallelStatefulRunsMultiThread() throws Exception {
+        detector.registerGatherer("g", false /* no combiner */, true);
+        integrateOnTwoThreads("g");
+
+        var report = detector.analyze();
+        assertTrue(report.hasIssues());
+        assertFalse(report.getMissingCombinerIssues().isEmpty());
+        String issue = report.getMissingCombinerIssues().get(0);
+        assertTrue(issue.contains("g"), issue);
+        assertTrue(issue.contains("combiner"), issue);
+    }
+
+    @Test
+    void emitsSharedStateWarning_forParallelMultiThread() throws Exception {
+        detector.registerGatherer("g", true, true);
+        integrateOnTwoThreads("g");
+
+        var report = detector.analyze();
+        assertFalse(report.getSharedStateIssues().isEmpty(),
+            "Concurrent integration should prompt a state-confinement check");
+    }
+
+    // ---- Unregistered gatherer ----
+
+    @Test
+    void ignoresUnregisteredGatherer() {
+        detector.recordIntegrate("never-registered", Thread.currentThread());
+        assertFalse(detector.analyze().hasIssues());
+    }
+
+    // ---- Null safety ----
+
+    @Test
+    void toleratesNullArguments() {
+        assertDoesNotThrow(() -> {
+            detector.registerGatherer(null, false, true);
+            detector.recordIntegrate(null, Thread.currentThread());
+            detector.recordIntegrate("g", null);
+        });
+    }
+
+    // ---- toString ----
+
+    @Test
+    void toString_isClean_whenNoIssues() {
+        assertTrue(detector.analyze().toString()
+            .contains("No unsafe parallel-gatherer usage"));
+    }
+
+    @Test
+    void toString_containsLearningContent_whenIssuesFound() throws Exception {
+        detector.registerGatherer("g", false, true);
+        integrateOnTwoThreads("g");
+
+        String str = detector.analyze().toString();
+        assertTrue(str.contains("LEARNING"), str);
+        assertTrue(str.contains("Gatherer"), str);
+        assertTrue(str.contains("combiner"), str);
+        assertTrue(str.contains("HIGH"), str);
+    }
+}

--- a/src/test/java/se/deversity/asynctest/diagnostics/StableValueMisuseDetectorTest.java
+++ b/src/test/java/se/deversity/asynctest/diagnostics/StableValueMisuseDetectorTest.java
@@ -1,0 +1,178 @@
+package se.deversity.asynctest.diagnostics;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link StableValueMisuseDetector}.
+ */
+class StableValueMisuseDetectorTest {
+
+    private StableValueMisuseDetector detector;
+
+    @BeforeEach
+    void setUp() {
+        detector = new StableValueMisuseDetector();
+    }
+
+    // ---- Happy path ----
+
+    @Test
+    void noIssues_whenSetThenRead() {
+        Thread t = Thread.currentThread();
+        detector.recordSet("CONFIG", t);
+        detector.recordRead("CONFIG", t);
+
+        var report = detector.analyze();
+        assertFalse(report.hasIssues(), "Expected no issues: " + report);
+        assertEquals(1, report.getTotalSets());
+        assertEquals(1, report.getTotalReads());
+    }
+
+    @Test
+    void noIssues_forOrElseSetSupplierThenRead() {
+        Thread t = Thread.currentThread();
+        detector.recordSupplierStart("CONFIG", t);
+        detector.recordSupplierEnd("CONFIG", t);
+        detector.recordRead("CONFIG", t); // value is set after supplier completes
+
+        var report = detector.analyze();
+        assertFalse(report.hasIssues(), "Expected no issues: " + report);
+    }
+
+    // ---- Read before set ----
+
+    @Test
+    void detectsReadBeforeSet() {
+        detector.recordRead("CONFIG", Thread.currentThread());
+
+        var report = detector.analyze();
+        assertTrue(report.hasIssues());
+        assertFalse(report.getReadBeforeSetIssues().isEmpty());
+        String issue = report.getReadBeforeSetIssues().get(0);
+        assertTrue(issue.contains("CONFIG"), issue);
+        assertTrue(issue.contains("NoSuchElementException"), issue);
+    }
+
+    @Test
+    void noReadBeforeSet_whenReadHappensAfterSet() {
+        Thread t = Thread.currentThread();
+        detector.recordSet("CONFIG", t);
+        detector.recordRead("CONFIG", t);
+        detector.recordRead("CONFIG", t);
+
+        assertTrue(detector.analyze().getReadBeforeSetIssues().isEmpty());
+    }
+
+    // ---- Double set ----
+
+    @Test
+    void detectsDoubleSet() {
+        Thread t = Thread.currentThread();
+        detector.recordSet("CONFIG", t);
+        detector.recordSet("CONFIG", t); // second set — violation
+
+        var report = detector.analyze();
+        assertTrue(report.hasIssues());
+        assertEquals(1, report.getDoubleSetIssues().size());
+        String issue = report.getDoubleSetIssues().get(0);
+        assertTrue(issue.contains("CONFIG"), issue);
+        assertTrue(issue.contains("already set"), issue);
+    }
+
+    @Test
+    void noDoubleSet_forDistinctHolders() {
+        Thread t = Thread.currentThread();
+        detector.recordSet("A", t);
+        detector.recordSet("B", t);
+
+        assertTrue(detector.analyze().getDoubleSetIssues().isEmpty());
+    }
+
+    // ---- Reentrant computation ----
+
+    @Test
+    void detectsReentrantSupplier() {
+        Thread t = Thread.currentThread();
+        detector.recordSupplierStart("CONFIG", t);
+        detector.recordSupplierStart("CONFIG", t); // re-entered while computing — violation
+
+        var report = detector.analyze();
+        assertTrue(report.hasIssues());
+        assertEquals(1, report.getReentrantIssues().size());
+        assertTrue(report.getReentrantIssues().get(0).contains("CONFIG"));
+    }
+
+    @Test
+    void noReentrancy_whenSupplierEndsBeforeRestart() {
+        Thread t = Thread.currentThread();
+        detector.recordSupplierStart("CONFIG", t);
+        detector.recordSupplierEnd("CONFIG", t);
+        detector.recordSupplierStart("CONFIG", t); // sequential, not reentrant
+        detector.recordSupplierEnd("CONFIG", t);
+
+        assertTrue(detector.analyze().getReentrantIssues().isEmpty());
+    }
+
+    // ---- Set contention ----
+
+    @Test
+    void detectsSetContention_whenManyThreadsRaceToSet() throws Exception {
+        Runnable r = () -> detector.recordSet("CONFIG", Thread.currentThread());
+        Thread a = new Thread(r), b = new Thread(r), c = new Thread(r);
+        a.start(); b.start(); c.start();
+        a.join(); b.join(); c.join();
+
+        var report = detector.analyze();
+        assertFalse(report.getContentionWarnings().isEmpty(),
+            "Three distinct threads racing one holder should warn");
+        assertTrue(report.getContentionWarnings().get(0).contains("CONFIG"));
+    }
+
+    // ---- Null safety ----
+
+    @Test
+    void toleratesNullArguments() {
+        assertDoesNotThrow(() -> {
+            detector.recordSet(null, Thread.currentThread());
+            detector.recordSet("K", null);
+            detector.recordRead(null, Thread.currentThread());
+            detector.recordRead("K", null);
+            detector.recordSupplierStart(null, null);
+            detector.recordSupplierEnd("K", null);
+        });
+    }
+
+    // ---- toString ----
+
+    @Test
+    void toString_isClean_whenNoIssues() {
+        assertTrue(detector.analyze().toString().contains("No StableValue misuse"));
+    }
+
+    @Test
+    void toString_containsLearningContent_whenIssuesFound() {
+        detector.recordRead("CONFIG", Thread.currentThread());
+        String str = detector.analyze().toString();
+        assertTrue(str.contains("LEARNING"), str);
+        assertTrue(str.contains("StableValue"), str);
+        assertTrue(str.contains("orElseSet"), str);
+    }
+
+    @Test
+    void toString_showsCritical_forReadBeforeSet() {
+        detector.recordRead("CONFIG", Thread.currentThread());
+        assertTrue(detector.analyze().toString().contains("CRITICAL"));
+    }
+
+    @Test
+    void toString_showsHigh_forDoubleSetOnly() {
+        Thread t = Thread.currentThread();
+        detector.recordSet("CONFIG", t);
+        detector.recordSet("CONFIG", t);
+        String str = detector.analyze().toString();
+        assertTrue(str.contains("HIGH"), str);
+    }
+}

--- a/src/test/java/se/deversity/asynctest/diagnostics/StructuredTaskScopeMisuseDetectorTest.java
+++ b/src/test/java/se/deversity/asynctest/diagnostics/StructuredTaskScopeMisuseDetectorTest.java
@@ -1,0 +1,181 @@
+package se.deversity.asynctest.diagnostics;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link StructuredTaskScopeMisuseDetector}.
+ */
+class StructuredTaskScopeMisuseDetectorTest {
+
+    private StructuredTaskScopeMisuseDetector detector;
+
+    @BeforeEach
+    void setUp() {
+        detector = new StructuredTaskScopeMisuseDetector();
+    }
+
+    // ---- Happy path: open -> fork -> join -> get -> close ----
+
+    @Test
+    void noIssues_forCorrectLifecycle() {
+        Thread owner = Thread.currentThread();
+        detector.recordScopeOpened("s", owner);
+        detector.recordFork("s", "a", owner);
+        detector.recordFork("s", "b", owner);
+        detector.recordJoin("s", owner);
+        detector.recordResultRead("s", "a", owner);
+        detector.recordResultRead("s", "b", owner);
+        detector.recordScopeClosed("s", owner);
+
+        var report = detector.analyze();
+        assertFalse(report.hasIssues(), "Expected clean lifecycle: " + report);
+        assertEquals(1, report.getTotalScopes());
+        assertEquals(2, report.getTotalForks());
+    }
+
+    // ---- Fork after join ----
+
+    @Test
+    void detectsForkAfterJoin() {
+        Thread owner = Thread.currentThread();
+        detector.recordScopeOpened("s", owner);
+        detector.recordFork("s", "a", owner);
+        detector.recordJoin("s", owner);
+        detector.recordFork("s", "late", owner); // violation
+
+        var report = detector.analyze();
+        assertTrue(report.hasIssues());
+        assertEquals(1, report.getForkAfterJoinIssues().size());
+        String issue = report.getForkAfterJoinIssues().get(0);
+        assertTrue(issue.contains("late"), issue);
+        assertTrue(issue.contains("IllegalStateException"), issue);
+    }
+
+    // ---- Result before join ----
+
+    @Test
+    void detectsResultReadBeforeJoin() {
+        Thread owner = Thread.currentThread();
+        detector.recordScopeOpened("s", owner);
+        detector.recordFork("s", "a", owner);
+        detector.recordResultRead("s", "a", owner); // before join — violation
+
+        var report = detector.analyze();
+        assertTrue(report.hasIssues());
+        assertEquals(1, report.getResultBeforeJoinIssues().size());
+        assertTrue(report.getResultBeforeJoinIssues().get(0).contains("a"));
+    }
+
+    @Test
+    void noResultIssue_whenReadAfterJoin() {
+        Thread owner = Thread.currentThread();
+        detector.recordScopeOpened("s", owner);
+        detector.recordFork("s", "a", owner);
+        detector.recordJoin("s", owner);
+        detector.recordResultRead("s", "a", owner);
+
+        assertTrue(detector.analyze().getResultBeforeJoinIssues().isEmpty());
+    }
+
+    // ---- Owner confinement ----
+
+    @Test
+    void detectsForkFromNonOwnerThread() throws Exception {
+        Thread owner = Thread.currentThread();
+        detector.recordScopeOpened("s", owner);
+
+        Thread other = new Thread(() -> detector.recordFork("s", "x", Thread.currentThread()));
+        other.start();
+        other.join();
+
+        var report = detector.analyze();
+        assertTrue(report.hasIssues());
+        assertEquals(1, report.getConfinementIssues().size());
+        assertTrue(report.getConfinementIssues().get(0).contains("WrongThreadException"));
+    }
+
+    @Test
+    void detectsJoinFromNonOwnerThread() throws Exception {
+        Thread owner = Thread.currentThread();
+        detector.recordScopeOpened("s", owner);
+        detector.recordFork("s", "a", owner);
+
+        Thread other = new Thread(() -> detector.recordJoin("s", Thread.currentThread()));
+        other.start();
+        other.join();
+
+        assertFalse(detector.analyze().getConfinementIssues().isEmpty());
+    }
+
+    // ---- Missing join ----
+
+    @Test
+    void detectsCloseWithoutJoin() {
+        Thread owner = Thread.currentThread();
+        detector.recordScopeOpened("s", owner);
+        detector.recordFork("s", "a", owner);
+        detector.recordScopeClosed("s", owner); // never joined — violation
+
+        var report = detector.analyze();
+        assertTrue(report.hasIssues());
+        assertEquals(1, report.getMissingJoinIssues().size());
+        assertTrue(report.getMissingJoinIssues().get(0).contains("without ever calling join()"));
+    }
+
+    @Test
+    void noMissingJoin_whenNoForks() {
+        Thread owner = Thread.currentThread();
+        detector.recordScopeOpened("s", owner);
+        detector.recordScopeClosed("s", owner); // empty scope, nothing to join
+
+        assertTrue(detector.analyze().getMissingJoinIssues().isEmpty());
+    }
+
+    // ---- Unknown scope id is ignored ----
+
+    @Test
+    void ignoresEventsForUnopenedScope() {
+        detector.recordFork("ghost", "a", Thread.currentThread());
+        detector.recordJoin("ghost", Thread.currentThread());
+        assertFalse(detector.analyze().hasIssues());
+    }
+
+    // ---- Null safety ----
+
+    @Test
+    void toleratesNullArguments() {
+        assertDoesNotThrow(() -> {
+            detector.recordScopeOpened(null, Thread.currentThread());
+            detector.recordScopeOpened("s", null);
+            detector.recordFork(null, "a", Thread.currentThread());
+            detector.recordFork("s", null, Thread.currentThread());
+            detector.recordJoin("s", null);
+            detector.recordResultRead("s", "a", null);
+            detector.recordScopeClosed(null, null);
+        });
+    }
+
+    // ---- toString ----
+
+    @Test
+    void toString_isClean_whenNoIssues() {
+        assertTrue(detector.analyze().toString().contains("No StructuredTaskScope misuse"));
+    }
+
+    @Test
+    void toString_containsLearningContent_whenIssuesFound() {
+        Thread owner = Thread.currentThread();
+        detector.recordScopeOpened("s", owner);
+        detector.recordFork("s", "a", owner);
+        detector.recordJoin("s", owner);
+        detector.recordFork("s", "late", owner);
+
+        String str = detector.analyze().toString();
+        assertTrue(str.contains("LEARNING"), str);
+        assertTrue(str.contains("StructuredTaskScope"), str);
+        assertTrue(str.contains("CRITICAL"), str);
+    }
+}


### PR DESCRIPTION
## Summary

Adds **three new concurrency detectors** targeting features introduced/finalized in **JDK 24–26**, plus complete documentation and runnable examples.

They are **standalone** — used directly (`recordXxx(...)` → `analyze()`) rather than wired into the `@AsyncTest` `detectAll` pipeline. A pipeline detector needs a `DetectorType` enum constant, and `DetectorType` is a **locked file** (adding a constant requires a synchronized six-place change). All three are modeled via `String` keys + `Thread` (no preview-API imports), so they **compile and run on the Java 21 baseline** while modeling JDK 24/25/26 APIs.

| Detector | JDK feature | Hazards detected |
|---|---|---|
| `StableValueMisuseDetector` | `StableValue` — JEP 502 (preview JDK 25 → 26) | read-before-set (`NoSuchElementException`), double-set (lost update / `IllegalStateException`), reentrant `orElseSet`, set-contention |
| `StructuredTaskScopeMisuseDetector` | `StructuredTaskScope.open(Joiner)` — JEP 505 (preview JDK 25 → final JDK 26) | fork-after-join, `Subtask.get()` before join, owner-confinement (`WrongThreadException`), close-without-join |
| `GathererConcurrencyMisuseDetector` | Stream Gatherers — JEP 485 (final JDK 24) | stateful gatherer on a parallel stream with no combiner (lost results), concurrent-integrator shared-state race |

Each follows the existing `diagnostics` detector pattern: thread-safe (`ConcurrentHashMap`/`newKeySet`), null-tolerant record API, and a typed `*Report` with `hasIssues()` + a `📚 LEARNING` block.

## Documentation updated
- `README.md` — detector table row + standalone note
- `.claude/SKILL.md` — record-API table + usage snippet
- `docs/ARCHITECTURE.md` — dedicated section (why standalone, how to promote) + file tree
- `docs/DETECTOR_CATALOG.md` — Buggy/Fixed/Detect entries
- `docs/CHANGELOG.md` — `[Unreleased]`
- `examples/README.md` + **examples 114–116** (runnable Maven projects)
- `consumer-fixture/README.md` + `ConsumerJdk25And26DetectorsTest`
- `CLAUDE.md` — VibeTags auto-registration (test-driven entries)

## Verification
- New detector tests: **34** (Stable 14 / StructuredTaskScope 12 / Gatherer 8) ✅
- Full library suite: **1249** tests ✅
- `checkstyle:check pmd:check spotbugs:check` ✅
- consumer-fixture against installed artifact: **126** (incl. new 6) ✅
- examples 114/115/116: **10** tests ✅

## Note on wiring
These are intentionally **not** added to `DetectorType` / `AsyncTestConfig` / the registry, since that enum is locked. Each doc explains the one-line path to promote them (enum constant + config flag, then `AsyncTestContext` accessor or `DetectorFactory` + `META-INF/services`) once a slot opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)